### PR TITLE
chore(deps): pin trivy-action to v0.36.0 post-supply-chain-incident

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # master
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'fs'
         scan-ref: '.'


### PR DESCRIPTION
Replaces the unversioned master-branch pin with v0.36.0, the latest stable release published after the March 2026 trivy ecosystem compromise. The old pin was also causing binary download failures at runtime (Trivy v0.65.0 installer exiting with code 1).