### PR TITLE
fix(ci): move security-events write permission to job level

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,13 +11,15 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 jobs:
   security-scan:
     name: Security Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
     steps:
     - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary

- Moves `security-events: write` and `actions: read` from the top-level `permissions` block to the `security-scan` job's `permissions` block
- Top-level permissions now only declare `contents: read`

## Why

The OpenSSF Scorecard Token-Permissions check scores 0 when any write permission is set at the top level. By restricting the top level to read-only and scoping write permissions to the job that actually needs them, the check should award a full score. The `security-events: write` permission is exempt from penalisation at the job level because `github/codeql-action/upload-sarif` is a recognised SARIF upload action.

## Test plan

- [ ] Confirm the Security Scan workflow runs successfully on this PR
- [ ] Confirm the OpenSSF Scorecard workflow passes (Token-Permissions score improved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)