### PR TITLE
fix(ci): move contents: write permission to job level in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,13 +6,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     name: Deploy to gh-pages branch
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
     - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary

- Restricts the top-level `permissions` block to `contents: read`
- Moves `contents: write` down to the `deploy` job level where it is actually needed (by `peaceiris/actions-gh-pages` to push to the `gh-pages` branch)

## Why

Follows the same pattern as #42 — the OpenSSF Scorecard Token-Permissions check scores 0 when any write permission is declared at the top level. Scoping write permissions to the job that needs them satisfies the principle of least privilege and should improve the score.

## Test plan

- [ ] Confirm the Deploy workflow runs successfully on merge to main
- [ ] Confirm the OpenSSF Scorecard Token-Permissions check score improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)