### PR TITLE
fix(simulation): clamp gammaRandom underflow to Number.MIN_VALUE for small shapes

### DIFF
--- a/src/simulation.js
+++ b/src/simulation.js
@@ -7,7 +7,10 @@ export function betaDistribution(alpha, beta) {
 export function gammaRandom(shape) {
     // Marsaglia and Tsang method
     if (shape < 1) {
-        return gammaRandom(shape + 1) * Math.pow(Math.random(), 1 / shape);
+        // Math.pow(u, 1/shape) underflows to 0 for small u when shape is small.
+        // Clamp to Number.MIN_VALUE: the true value is near-zero, not zero.
+        const scale = Math.pow(Math.random(), 1 / shape) || Number.MIN_VALUE;
+        return gammaRandom(shape + 1) * scale;
     }
 
     const d = shape - 1/3;


### PR DESCRIPTION
## Summary

- Fixes a flaky failure in the `gammaRandom` property-based test where shape values close to 0 (e.g. `0.01`) caused `Math.pow(u, 1/shape)` to underflow to `0`, violating the invariant that `gammaRandom` always returns a strictly positive value
- For `shape = 0.01`, the exponent is `100` — any `u < ~0.0006` produces `0` in double precision
- Fix clamps the underflowed result to `Number.MIN_VALUE` rather than retrying with a new random draw, which would substitute a potentially much larger value and distort the distribution

## Test plan

- [ ] `npm test` passes consistently across multiple runs — the previously flaky `also works for shape < 1` test should now be stable
- [ ] No change to simulation output for realistic inputs: in practice `gammaRandom` is only called with `shape >= 0.5` (enforced by `Math.max(0.5, ...)` in `generateTaskEffortHelper`), so this fix has no effect on normal application behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)