### PR TITLE
docs(adr): RFC 4180 CSV compliance and PapaParse selection (ADR-0007/0008), extend dependency policy to CDN (ADR-0005)

### DIFF
--- a/docs/adr/0005-dependency-decision-policy.md
+++ b/docs/adr/0005-dependency-decision-policy.md
@@ -16,20 +16,27 @@ A lightweight, consistent policy ensures that each addition to the dependency gr
 
 ### Adding a dependency
 
-Any new direct dependency — whether a production or development dependency — requires an ADR before it is added to `package.json`. The ADR must document:
+Any new direct dependency requires an ADR before it is introduced. This policy applies to:
+
+- **npm dependencies** — any addition to `dependencies` or `devDependencies` in `package.json`
+- **CDN-linked runtime libraries** — any third-party script added to `src/template.html` via a `<script src="…">` tag
+
+The ADR must document:
 
 1. **What the dependency does** and why it is needed
 2. **Alternatives considered** and why they were not chosen
-3. **Supply chain implications**: approximate transitive dependency count, whether lifecycle scripts are required, and how it fits within the existing pinning and `--ignore-scripts` policy
+3. **Supply chain implications**, which differ by dependency type:
+   - *npm*: approximate transitive dependency count, whether lifecycle scripts are required, and how it fits within the existing pinning and `--ignore-scripts` policy
+   - *CDN*: no transitive npm packages are introduced, but the CDN URL and version must be pinned with a Subresource Integrity (SRI) hash in `src/template.html`; the ADR must record the pinned version and note that the SRI hash must be updated on upgrade
 4. **Health assessment** against the criteria below
 
-Transitive dependencies introduced by an approved direct dependency do not each require their own ADR, but the ADR for the direct dependency should acknowledge the transitive surface.
+Transitive dependencies introduced by an approved direct npm dependency do not each require their own ADR, but the ADR for the direct dependency should acknowledge the transitive surface.
 
-This policy applies to both `dependencies` and `devDependencies`. Dev dependencies run in CI and developer environments and carry the same supply chain risk as production dependencies in this context.
+Dev dependencies run in CI and developer environments and carry the same supply chain risk as production dependencies in this context.
 
 ### Existing dependencies
 
-The four dependencies present when this ADR was adopted (`eslint`, `fast-check`, `html-validate`, `vitest`) are grandfathered in. They do not require retroactive ADRs for their original adoption decision, but they must be included in the first periodic health review and any findings recorded at that time.
+The four npm dependencies present when this ADR was adopted (`eslint`, `fast-check`, `html-validate`, `vitest`) are grandfathered in. The CDN dependency Chart.js, also present at that time, is similarly grandfathered in. None of these require retroactive ADRs for their original adoption decision, but they must be included in the first periodic health review and any findings recorded at that time.
 
 ### Periodic review
 
@@ -94,6 +101,7 @@ Writing an ADR for a dependency takes less time than the evaluation that should 
 - Periodic review requires discipline to schedule and act on; without a trigger it can be deferred indefinitely
 - Health criteria involve judgement calls (e.g. what counts as "responsive"); the table provides guidance but not a mechanical pass/fail
 - Does not cover indirect upgrades to transitive dependencies (Dependabot PRs); those are handled by the existing lock file and integrity verification controls
+- CDN dependency compliance is not mechanically enforceable: there is no CDN equivalent of `package-lock.json`. Correct SRI pinning and health assessment depend on the same human review and ADR discipline as the rest of the policy
 
 ## Alternatives Considered
 
@@ -125,4 +133,5 @@ Use a tool such as `license-checker` or a custom script to block unapproved pack
 
 - [ADR-0003: Property-Based Testing](./0003-property-based-testing.md) — establishes the supply chain controls this policy builds on
 - [ADR-0004: Branch Policy](./0004-branch-policy.md) — analogous lightweight process policy
+- [ADR-0008: PapaParse CDN Dependency](./0008-papaparse-cdn-dependency.md) — first CDN dependency added under the extended policy
 - [Dependency review log](../development/dependency-review-log.md)

--- a/docs/adr/0007-rfc4180-csv-compliance.md
+++ b/docs/adr/0007-rfc4180-csv-compliance.md
@@ -1,0 +1,100 @@
+# ADR-0007: RFC 4180 Compliance for CSV Import and Export
+
+## Status
+
+Accepted
+
+## Context
+
+The application supports importing and exporting task configurations as CSV files. The current implementation in `src/ui.js` (`parseCSV`, line 548, and the export block, line 613) does not comply with [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180), the de-facto standard for CSV interchange.
+
+Known non-conformances in the current implementation:
+
+1. **Line splitting on `\n` only** — RFC 4180 specifies CRLF (`\r\n`) as the canonical line terminator. Splitting only on `\n` leaves a trailing `\r` on every field in files produced by Windows tools or conforming generators, silently corrupting numeric values on import.
+
+2. **Field splitting on bare `,`** — `lines[i].split(',')` breaks whenever a task name contains a comma (e.g. `"Design, build, test"`), producing too many fields and misaligning all subsequent columns for that row.
+
+3. **Naive quote stripping via `.replace(/"/g, '')`** — removes every double-quote character unconditionally. It does not handle the RFC 4180 rule that a literal double-quote inside a quoted field must be escaped as `""`. A task named `Say "hello"` would be mangled on round-trip.
+
+4. **Export does not escape embedded double-quotes** — the export template wraps only the task name column in quotes (`"${task[0]}"`) but does not escape any `"` characters already present in the name, producing malformed CSV that no conforming parser can read back correctly.
+
+These defects mean that CSV files produced by Excel, Google Sheets, or any RFC 4180-conforming tool may fail to import correctly, and files exported by the application may not be readable by those tools.
+
+## Decision
+
+CSV import and export in this application must conform to RFC 4180. The implementation will delegate parsing and serialisation to a browser-compatible external library, loaded via CDN with a Subresource Integrity (SRI) hash, per the dependency policy in ADR-0005. The specific library selection is recorded in ADR-0008.
+
+Behavioural requirements:
+
+- **Import** must correctly parse quoted fields, including fields containing embedded commas and embedded newlines.
+- **Import** must unescape `""` sequences inside quoted fields to a single `"`.
+- **Import** must accept both CRLF and LF line endings (LF tolerance is a pragmatic allowance for Unix-generated files).
+- **Export** must use CRLF line terminators.
+- **Export** must quote any field whose value contains a comma, double-quote, or newline.
+- **Export** must escape any double-quote character in a field value as `""`.
+
+The header row is always present; it is skipped on import and emitted on export.
+
+## Rationale
+
+### Interoperability
+
+Task lists are likely to be authored or reviewed in spreadsheet tools (Excel, Google Sheets, LibreOffice Calc). All of these generate RFC 4180-conformant CSV. Accepting only a non-standard subset creates a silent data-corruption path that is hard for users to diagnose.
+
+### Round-trip fidelity
+
+The application allows any string as a task name. Names containing commas or quotation marks (common in prose descriptions) currently produce corrupt CSV on export and fail to re-import. Compliance is the minimum required to guarantee a lossless round-trip for all task names.
+
+### Delegating a well-specified but edge-case-heavy problem
+
+RFC 4180 is short but its full implementation is non-trivial: quoted fields, embedded newlines, escaped quotes, BOM handling, and CRLF vs LF tolerance each represent a distinct code path. Mature browser-compatible CSV libraries carry large test suites and years of production use covering these cases. Implementing this in-house means owning all of those edge cases indefinitely with no equivalent test coverage.
+
+The CDN model, already in use for Chart.js, is the appropriate integration mechanism for a browser-only dependency with no npm footprint.
+
+## Consequences
+
+### Positive
+
+- CSV files exported by the application will be importable by Excel, Google Sheets, and any other RFC 4180-conforming tool without data loss.
+- CSV files produced by those tools will import without corruption, even when task names contain commas or quotation marks.
+- Round-trip fidelity: export followed by import produces an identical task list for all valid task names.
+- Edge cases (BOM, embedded newlines, escaped quotes, CRLF/LF) are handled by a battle-tested external implementation rather than in-house code.
+- Files exported before this change used LF endings and unescaped quotes; they remain importable provided the chosen library tolerates LF line endings.
+
+### Negative
+
+- A second CDN runtime dependency is introduced. Like Chart.js, this creates a runtime availability dependency on cdnjs; if cdnjs is unreachable the CSV feature will not function.
+- The SRI hash in `src/template.html` must be updated whenever the library version is upgraded.
+
+## Alternatives Considered
+
+### Alternative 1: Custom RFC 4180-compliant implementation
+
+Implement a compliant parser and serialiser in-house within `src/simulation.js` or `src/ui.js`.
+
+**Rejected because**: RFC 4180 has enough edge cases that a correct implementation requires meaningful ongoing maintenance and testing. The cost of in-house ownership is not justified when healthy browser-compatible libraries are available via the CDN mechanism already in use.
+
+### Alternative 2: Node.js-native CSV libraries (csv-parse, fast-csv, etc.)
+
+Use a Node.js-native library from npm.
+
+**Rejected because**: Node.js-native libraries cannot be loaded via CDN and require a bundler to run in the browser — adding a bundler would conflict with the intentionally minimal build step established in ADR-0002.
+
+### Alternative 3: Restrict task name input to disallow commas and quotes
+
+Validate task names on entry to reject characters that break the naive parser.
+
+**Rejected because**: task names are prose; commas and quotation marks are natural. Restricting input to work around a deficient parser trades a parsing problem for a permanent usability constraint.
+
+### Alternative 4: Switch to a different interchange format (JSON, TSV)
+
+Replace CSV with JSON or tab-separated values, which have simpler parsing rules.
+
+**Rejected because**: CSV is already the shipped format and is what users expect from a spreadsheet-friendly tool. Migrating breaks all existing exported files. The problem is solvable within the CSV format.
+
+## References
+
+- [RFC 4180 – Common Format and MIME Type for Comma-Separated Values (CSV) Files](https://www.rfc-editor.org/rfc/rfc4180)
+- [ADR-0002: Source Restructuring and Build Step](0002-source-restructuring-and-build-step.md)
+- [ADR-0005: Dependency Decision Policy](0005-dependency-decision-policy.md)
+- [ADR-0008: PapaParse CDN Dependency](0008-papaparse-cdn-dependency.md)

--- a/docs/adr/0008-papaparse-cdn-dependency.md
+++ b/docs/adr/0008-papaparse-cdn-dependency.md
@@ -1,0 +1,108 @@
+# ADR-0008: PapaParse as the CSV Library
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0007 mandates RFC 4180 compliance for CSV import and export, and decides to delegate parsing and serialisation to a browser-compatible external library loaded via CDN. This ADR records the library selection per the dependency policy in ADR-0005.
+
+The requirements from ADR-0007 constrain the candidate pool to libraries that:
+
+- run in the browser without a bundler (CDN-distributable)
+- are RFC 4180 compliant
+- can be loaded via cdnjs (consistent with the existing Chart.js pattern)
+
+## Decision
+
+Use **PapaParse** (v5.x) as the CSV parsing and serialisation library. Load it from cdnjs with a Subresource Integrity hash pinned in `src/template.html`.
+
+## Rationale
+
+### Only viable browser-native candidate
+
+The major JavaScript CSV libraries split into two groups:
+
+| Library | Browser-compatible? | CDN-distributable? |
+|---|---|---|
+| **PapaParse** | Yes | Yes |
+| csv-parse | No (Node.js streams) | No |
+| fast-csv | No (Node.js streams) | No |
+| d3-dsv | Yes | Yes |
+
+csv-parse and fast-csv depend on Node.js stream primitives and cannot run in the browser without a bundler. That leaves PapaParse and d3-dsv as viable candidates.
+
+### PapaParse over d3-dsv
+
+d3-dsv is part of the D3 visualisation ecosystem and provides competent RFC 4180 parsing. PapaParse is preferred on two grounds:
+
+1. **Purpose-built for the use case**: PapaParse is a standalone CSV parser designed specifically for browser use, including file input handling, streaming large files, and explicit RFC 4180 compliance documentation. d3-dsv is a general delimiter-separated-values library that handles CSV as one of several formats; its browser CSV support is functional but not its primary focus.
+
+2. **Adoption signal**: PapaParse has 5–11M weekly npm downloads vs d3-dsv's lower standalone count. Broader adoption means more edge cases exercised in production and a larger community surface for catching bugs.
+
+## Health Assessment
+
+Assessed 2026-05-10 against the criteria in ADR-0005.
+
+| Criterion | Assessment |
+|---|---|
+| **Maintenance activity** | ✅ v5.5.x released within 12 months; active commit history |
+| **Security posture** | ✅ One past ReDOS vulnerability, patched promptly; no current CVEs with CVSS ≥ 7.0 |
+| **Issue and PR responsiveness** | ✅ Maintainers engaged; active issue tracker on a high-traffic project |
+| **Download trend** | ✅ 5–11M weekly downloads (source-dependent); stable trajectory |
+| **Maintainer continuity** | ✅ 2 listed maintainers; broad community usage |
+| **Explicit deprecation or successor** | ✅ Not deprecated; no known recommended replacement |
+
+## Supply Chain Implications
+
+- **npm dependencies added**: none — PapaParse is not installed via npm
+- **CDN URL**: `https://cdnjs.cloudflare.com/ajax/libs/PapaParse/<version>/papaparse.min.js`
+- **Integrity control**: SRI hash pinned in `src/template.html`; must be updated on version upgrade
+- **Runtime availability**: requires cdnjs to be reachable — the same availability dependency already accepted for Chart.js
+- **Transitive surface**: none (PapaParse has no production dependencies)
+- **Page weight**: approximately 50 KB uncompressed (~20 KB gzip)
+
+## Consequences
+
+### Positive
+
+- RFC 4180 compliance delivered by a purpose-built, battle-tested library with years of production edge-case coverage
+- No npm supply chain addition; no lock file changes; no `--ignore-scripts` exposure
+- Consistent with the Chart.js CDN pattern — no new infrastructure or build process required
+- SRI pinning enforced by the browser; the file cannot be substituted at the CDN without breaking the hash check
+
+### Negative
+
+- A second CDN runtime dependency is introduced; the CSV feature fails if cdnjs is unreachable
+- The SRI hash must be manually updated when upgrading PapaParse — Dependabot does not cover CDN dependencies
+- ~20 KB of additional page weight (gzip)
+
+## Alternatives Considered
+
+### Alternative 1: d3-dsv
+
+A delimiter-separated-values library from the D3 ecosystem; RFC 4180 capable and browser-compatible.
+
+**Rejected because**: d3-dsv is general-purpose and not primarily focused on browser CSV; PapaParse is purpose-built for this use case and has broader adoption indicating more thorough real-world validation.
+
+### Alternative 2: csv-parse
+
+The most widely downloaded CSV library on npm (~1.4M weekly downloads); RFC 4180 compliant.
+
+**Rejected because**: csv-parse targets Node.js stream environments and cannot be loaded via CDN without a bundler.
+
+### Alternative 3: fast-csv
+
+A Node.js streaming CSV library.
+
+**Rejected because**: same reason as csv-parse — Node.js-only, not CDN-distributable.
+
+## References
+
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md)
+- [ADR-0007: RFC 4180 Compliance for CSV Import and Export](./0007-rfc4180-csv-compliance.md)
+- [PapaParse documentation](https://www.papaparse.com/)
+- [PapaParse on cdnjs](https://cdnjs.cloudflare.com/ajax/libs/PapaParse/)
+- [PapaParse GitHub](https://github.com/mholt/PapaParse)
+- [Subresource Integrity – MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)


### PR DESCRIPTION
## Summary

- **ADR-0007**: Mandates RFC 4180 compliance for CSV import and export, documenting the four non-conformances in the current naive implementation and deciding to delegate to an external browser-compatible CDN library
- **ADR-0008**: Records the library selection decision — evaluates PapaParse, d3-dsv, csv-parse, and fast-csv; selects PapaParse with a full health assessment and supply chain implications per ADR-0005
- **ADR-0005** (updated): Extends the dependency policy to cover CDN-linked runtime libraries alongside npm dependencies, grandfathers Chart.js, and adds a negative consequence noting CDN compliance is not mechanically enforceable

## Test plan

- [ ] Review ADR-0007 — does the approach decision (use external CDN library) stand on its own without naming PapaParse?
- [ ] Review ADR-0008 — is the library evaluation and health assessment sufficient to justify the selection?
- [ ] Review ADR-0005 updates — does the CDN dependency scope feel complete and consistent with the npm policy?
- [ ] Check cross-references between all three documents are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)