### PR TITLE
docs: prefer pipx over pip for pre-commit installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ MIT License - see LICENSE file for details
 1. Fork the repository and clone your fork
 2. Create a branch: `git checkout -b <type>/<short-description>` (types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`)
 3. Install dependencies: `npm install --ignore-scripts`
-4. Install pre-commit hooks: `pip install pre-commit && pre-commit install`
+4. Install pre-commit hooks: `pipx install pre-commit && pre-commit install` (or `pip install pre-commit && pre-commit install`)
 5. Edit source files in `src/` — do not edit `web/index.html` directly
 6. Run tests: `npm test`
 7. Build: `npm run build`

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing to this project! This document provi
 3. Install pre-commit hooks (if not already installed on your system):
 
    ```bash
-   pip install pre-commit
+   pipx install pre-commit  # recommended; or: pip install pre-commit
    pre-commit install
    ```
 


### PR DESCRIPTION
## Summary

- Updates `README.md` and `docs/development/CONTRIBUTING.md` to recommend `pipx install pre-commit` as the preferred installation method
- Retains `pip install pre-commit` as a documented fallback

`pipx` is the [officially recommended](https://pre-commit.com/#installation) install method for pre-commit as it isolates CLI tools in their own virtualenvs, avoiding conflicts with project dependencies.

## Test plan

- [ ] Verify both files show `pipx` as the primary option with `pip` as fallback