### PR TITLE
chore: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 web/index.html
+.DS_Store


### PR DESCRIPTION
## Summary

- Adds `.DS_Store` to `.gitignore` to prevent macOS metadata files from appearing as untracked changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)