### PR TITLE
chore: bump Chart.js CDN from 4.4.1 to 4.5.0

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -362,8 +362,8 @@
         <div id="results" style="display: none;"></div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"
-            integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw=="
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"
+            integrity="sha512-Y51n9mtKTVBh3Jbx5pZSJNDDMyY+yGe77DGtBPzRlgsf/YLCh13kSZ3JmfHGzYFCmOndraf0sQgfM654b7dJ3w=="
             crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"
             integrity="sha512-dfX5uYVXzyU8+KHqj8bjo7UkOdg18PaOtpa48djpNbZHwExddghZ+ZmzWT06R5v6NSk3ZUfsH6FNEDepLx9hPQ=="


### PR DESCRIPTION
## Summary

- Bumps the Chart.js CDN pin in `src/template.html` from 4.4.1 to 4.5.0
- Updates the SRI hash to match the 4.5.0 `chart.umd.min.js` artifact on cdnjs
- No functional changes; the 4.4.x→4.5.0 releases contain no security fixes (Snyk confirms 4.4.1 has no known CVEs)

Identified during the first periodic dependency review (ADR-0005). A companion PR will update the dependency review log with the full Chart.js health assessment.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — all 26 tests pass
- [ ] Open `web/index.html` in a browser and verify charts render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)