### PR TITLE
feat: simulation complexity limits

### DIFF
--- a/docs/features/simulation-complexity-limits.md
+++ b/docs/features/simulation-complexity-limits.md
@@ -100,6 +100,7 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 - Error messages appear inline adjacent to the relevant input, not in alert dialogs
 - The complexity budget warning is an inline banner, not a blocking dialog — the user can proceed
 - Rejection (not clamping) is the model for hard limits: the run does not start until the user corrects the value
+- CSV imports with more than 100 valid task rows are rejected entirely with an error message; the existing task list is left unchanged so the user does not lose their current work
 
 ## Testing
 
@@ -107,7 +108,9 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 
 - simulations set to 25,001: Run button disabled, error shown
 - programQuantity set to 101: Run button disabled, error shown
-- 101st task added: Add Task button disabled, limit message shown
+- 101st task added via UI: Add Task button disabled, limit message shown
+- CSV imported with > 100 valid task rows: import rejected with an error message, existing tasks unchanged
+- CSV imported with ≤ 100 tasks: loads normally, no warning
 - All inputs at their maximums (25,000 × 100 × 100 = 250M ops): budget warning shown, Run still available
 - simulations = 1,000, programQuantity = 5, tasks = 3 (15,000 ops): no warning, runs normally
 - HTML `max` attribute removed via DevTools, value set above limit: JavaScript validation still blocks run
@@ -117,10 +120,13 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 
 1. Set simulations to 25,001 — confirm Run is disabled and error is visible
 2. Correct to 25,000 — confirm Run re-enables and error clears
-3. Add tasks until the 100th — confirm Add Task disables and message appears
-4. Set simulations = 25,000, programQuantity = 10, tasks = 20 (5M ops) — click Run, confirm budget warning appears without blocking
-5. Click Run again (or "Run anyway") — confirm simulation starts and progress bar appears
-6. Via browser DevTools, remove the `max` attribute from the simulations input, enter 100,000, click Run — confirm JavaScript validation catches it
+3. Set programQuantity to 101 — confirm Run is disabled and error is visible
+4. Correct to 100 — confirm Run re-enables and error clears
+5. Add tasks until the 100th — confirm Add Task disables and message appears
+6. Import a CSV with more than 100 valid task rows — confirm the import is rejected with an error message and the existing task list is unchanged
+7. Set simulations = 25,000, programQuantity = 10, tasks = 20 (5M ops) — click Run, confirm budget warning appears without blocking
+8. Click "Run anyway" — confirm simulation starts and progress bar appears
+9. Via browser DevTools, remove the `max` attribute from the simulations input, enter 100,000, click Run — confirm JavaScript validation catches it
 
 ## Performance Considerations
 

--- a/docs/features/simulation-complexity-limits.md
+++ b/docs/features/simulation-complexity-limits.md
@@ -22,7 +22,9 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 **Hard limits — input-level rejection:**
 - Inputs for simulations and program quantity enforce their maximum values via `max` attributes in HTML and validation checks in JavaScript
 - When a value exceeds the limit the input is styled as invalid (red border) and the Run button is disabled until corrected
-- An inline error message appears adjacent to the offending input explaining the limit
+- The Run button is visually styled as inactive (greyed out, not-allowed cursor) when disabled, so it is clearly distinguishable from an active button
+- The Run button's tooltip describes which validation is currently failing (e.g. "Simulation runs exceed the maximum of 25,000"), surfacing the reason without requiring the user to find the error message in the form
+- An inline error message also appears adjacent to the offending input explaining the limit
 
 **Task count limit:**
 - The Add Task button is disabled once 100 tasks are present
@@ -97,6 +99,7 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 
 - Each numeric input is validated on `input` and `change` events
 - A value below `min` or above `max` renders the input invalid and disables Run
+- When disabled, the Run button is visually greyed out (not merely unclickable) and its tooltip names the failing validation
 - Error messages appear inline adjacent to the relevant input, not in alert dialogs
 - The complexity budget warning is an inline banner, not a blocking dialog — the user can proceed
 - Rejection (not clamping) is the model for hard limits: the run does not start until the user corrects the value

--- a/docs/features/simulation-complexity-limits.md
+++ b/docs/features/simulation-complexity-limits.md
@@ -1,0 +1,143 @@
+# Feature: Simulation Complexity Limits
+
+## Overview
+
+Imposes per-input hard limits and a combined complexity budget on the three variables that determine simulation runtime (`simulations × programQuantity × tasks`), preventing accidental browser lock-up without silently misrepresenting the parameters the user configured.
+
+## User Story
+
+As a capacity planner, I want the tool to warn me before I kick off an unreasonably expensive simulation run so that I don't accidentally freeze my browser, while still being able to proceed if I know what I'm doing.
+
+## Functionality
+
+### Core Features
+
+- Hard upper limit on each of the three runtime-scaling inputs: simulations (25,000), program quantity (100), tasks (100)
+- A combined complexity budget of 5,000,000 operations (`simulations × programQuantity × tasks`) that triggers an inline warning before the run starts
+- The user can dismiss the warning and proceed; the budget is advisory, not a hard block
+- Values that exceed a hard limit are rejected (input turns invalid, Run is blocked) rather than silently clamped — the user must trust that results reflect the parameters they set
+
+### User Interface
+
+**Hard limits — input-level rejection:**
+- Inputs for simulations and program quantity enforce their maximum values via `max` attributes in HTML and validation checks in JavaScript
+- When a value exceeds the limit the input is styled as invalid (red border) and the Run button is disabled until corrected
+- An inline error message appears adjacent to the offending input explaining the limit
+
+**Task count limit:**
+- The Add Task button is disabled once 100 tasks are present
+- A message near the button reads "Maximum of 100 tasks reached"
+
+**Complexity budget — inline warning:**
+- If the product of all three variables exceeds 5,000,000 at the moment Run is clicked, an inline warning banner appears above the results area (not a blocking alert)
+- The banner states the estimated operation count, e.g.: "This configuration (~8M operations) may take a long time. Reduce simulations, program quantity, or tasks — or click Run to proceed."
+- The Run button remains active; clicking it again (or a "Run anyway" action in the banner) proceeds
+- The progress bar already visible during runs provides feedback that work is in progress
+
+### Data Flow
+
+1. On every input change, a validation function checks each field against its hard limit and recomputes the complexity product
+2. If any hard limit is breached, the Run button is disabled and error indicators are shown
+3. On Run click, if no hard limits are breached but the budget is exceeded, the warning banner is rendered and the simulation is paused pending user confirmation
+4. On confirmation (or if the budget is within range), `runSimulationAsync()` proceeds as normal
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+- **User inputs**: Numeric form fields for simulations, program quantity, and task count — all client-side, no server involved
+
+#### Outbound Data Vectors
+- None introduced by this feature
+
+#### Trust Boundaries
+- **Browser to application**: Numeric inputs are the only trust boundary. HTML `max` attributes are not sufficient alone — JavaScript validation is required as a second check since attributes can be bypassed via DevTools
+
+### Threat Model
+
+- **DoS via resource exhaustion**: A user (or a page loaded with crafted query parameters in a future feature) submits extreme values → Mitigation: hard limits enforced in JavaScript regardless of HTML attribute state
+- **Silent result distortion**: Clamping a value without telling the user would produce results that don't match stated parameters → Mitigation: rejection model ensures the value the user sees is the value used
+
+### Security Controls
+
+- All numeric inputs validated in JavaScript before the simulation loop is entered
+- No data leaves the browser; no new network surface introduced
+
+## Implementation Details
+
+### Key Components
+
+- **`src/template.html`**: Add `max` attributes to the simulations and programQuantity inputs; disable Add Task button at limit
+- **`src/ui.js` — `addTask()`**: Check task count before inserting; show limit message and disable button when at 100
+- **`src/ui.js` — input validation**: Live validation on change events for simulations and programQuantity; set invalid state and disable Run button on breach
+- **`src/ui.js` — `runSimulationAsync()`**: Compute complexity product before the simulation loop; render warning banner and await confirmation if budget exceeded
+
+### Code Location
+
+- Simulations input: `src/template.html` line 274
+- Program quantity input: `src/template.html` line 270
+- `addTask()`: `src/ui.js` line 8
+- `runSimulationAsync()`: `src/ui.js` line 60
+
+### Dependencies
+
+- No new external dependencies
+
+## Configuration
+
+| Parameter | Hard Limit | Default | Rationale |
+|-----------|-----------|---------|-----------|
+| Simulations | 25,000 | 1,000 | Allows high-fidelity runs while bounding worst-case cost |
+| Program quantity | 100 | 3 | Permits large parallel program portfolios |
+| Tasks | 100 | 3 (initial rows) | Generous ceiling; beyond this the UI becomes unwieldy |
+| Complexity budget | 5,000,000 ops | — | Advisory warning threshold; ~300k ops takes ~12s at observed throughput, so 5M is a meaningful signal |
+
+## Validation & Error Handling
+
+- Each numeric input is validated on `input` and `change` events
+- A value below `min` or above `max` renders the input invalid and disables Run
+- Error messages appear inline adjacent to the relevant input, not in alert dialogs
+- The complexity budget warning is an inline banner, not a blocking dialog — the user can proceed
+- Rejection (not clamping) is the model for hard limits: the run does not start until the user corrects the value
+
+## Testing
+
+### Test Cases
+
+- simulations set to 25,001: Run button disabled, error shown
+- programQuantity set to 101: Run button disabled, error shown
+- 101st task added: Add Task button disabled, limit message shown
+- All inputs at their maximums (25,000 × 100 × 100 = 250M ops): budget warning shown, Run still available
+- simulations = 1,000, programQuantity = 5, tasks = 3 (15,000 ops): no warning, runs normally
+- HTML `max` attribute removed via DevTools, value set above limit: JavaScript validation still blocks run
+- Complexity warning shown and Run clicked: simulation proceeds with original parameters unchanged
+
+### Manual Testing Steps
+
+1. Set simulations to 25,001 — confirm Run is disabled and error is visible
+2. Correct to 25,000 — confirm Run re-enables and error clears
+3. Add tasks until the 100th — confirm Add Task disables and message appears
+4. Set simulations = 25,000, programQuantity = 10, tasks = 20 (5M ops) — click Run, confirm budget warning appears without blocking
+5. Click Run again (or "Run anyway") — confirm simulation starts and progress bar appears
+6. Via browser DevTools, remove the `max` attribute from the simulations input, enter 100,000, click Run — confirm JavaScript validation catches it
+
+## Performance Considerations
+
+- Validation runs on input events and is O(1) — negligible cost
+- The complexity product is a single multiplication; no simulation work happens until confirmed
+- The feature reduces worst-case runtime by orders of magnitude; no new performance cost introduced
+
+## Known Limitations
+
+- The complexity budget is a rough heuristic based on observed throughput with a small number of simple tasks; actual runtime varies with task configuration and device capability
+- There is no adaptive throttling or Web Worker offloading — simulation still runs on the main thread
+
+## Future Enhancements
+
+- Move simulation loop to a Web Worker to keep the UI fully responsive during long runs
+- Adaptive budget estimate based on a short benchmark run on the user's device
+
+## Related Documentation
+
+- [Template](./template.md)

--- a/src/template.html
+++ b/src/template.html
@@ -253,6 +253,33 @@
             width: 0%;
             transition: width 0.3s ease;
         }
+        .input-error {
+            border-color: #e74c3c !important;
+        }
+        .input-error-msg {
+            color: #e74c3c;
+            font-size: 0.75em;
+            margin-top: 3px;
+            display: none;
+        }
+        .complexity-warning {
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 6px;
+            padding: 12px 16px;
+            margin-top: 16px;
+            display: none;
+            font-size: 0.9em;
+        }
+        .complexity-warning button {
+            margin-left: 12px;
+            padding: 4px 12px;
+            border: 1px solid #856404;
+            border-radius: 4px;
+            background: transparent;
+            cursor: pointer;
+            font-size: 0.9em;
+        }
     </style>
 </head>
 <body>
@@ -267,11 +294,13 @@
                 </div>
                 <div class="setting-item">
                     <label>Program Quantity</label>
-                    <input type="number" id="programQuantity" value="3" min="1" title="Number of parallel series to execute">
+                    <input type="number" id="programQuantity" value="3" min="1" max="100" title="Number of parallel series to execute">
+                    <span id="programQuantityError" class="input-error-msg">Maximum 100</span>
                 </div>
                 <div class="setting-item">
                     <label>Simulation Runs</label>
-                    <input type="number" id="simulations" value="1000" min="100">
+                    <input type="number" id="simulations" value="1000" min="100" max="25000">
+                    <span id="simulationsError" class="input-error-msg">Maximum 25,000</span>
                 </div>
                 <div class="setting-item">
                     <label>Confidence Level (%)</label>
@@ -341,7 +370,8 @@
                     <button type="button" class="remove-btn" onclick="removeTask(this)">Remove</button>
                 </div>
             </div>
-            <button type="button" class="btn btn-secondary" onclick="addTask()">Add Task</button>
+            <button type="button" class="btn btn-secondary" id="addTaskBtn" onclick="addTask()">Add Task</button>
+            <span id="taskLimitMessage" style="display:none; margin-left:10px; font-size:0.85em; color:#666;">Maximum of 100 tasks reached</span>
         </div>
 
         <div class="button-container">
@@ -358,6 +388,8 @@
                 </div>
             </div>
         </div>
+
+        <div id="complexityWarning" class="complexity-warning"></div>
 
         <div id="results" style="display: none;"></div>
     </div>

--- a/src/template.html
+++ b/src/template.html
@@ -275,6 +275,12 @@
             display: none;
             font-size: 0.9em;
         }
+        .task-limit-message {
+            display: none;
+            margin-left: 10px;
+            font-size: 0.85em;
+            color: #666;
+        }
         .complexity-warning button {
             margin-left: 12px;
             padding: 4px 12px;
@@ -375,7 +381,7 @@
                 </div>
             </div>
             <button type="button" class="btn btn-secondary" id="addTaskBtn" onclick="addTask()">Add Task</button>
-            <span id="taskLimitMessage" style="display:none; margin-left:10px; font-size:0.85em; color:#666;">Maximum of 100 tasks reached</span>
+            <span id="taskLimitMessage" class="task-limit-message">Maximum of 100 tasks reached</span>
         </div>
 
         <div class="button-container">

--- a/src/template.html
+++ b/src/template.html
@@ -68,6 +68,10 @@
         .btn:hover {
             background: #2980b9;
         }
+        .btn:disabled {
+            background: #95a5a6;
+            cursor: not-allowed;
+        }
         .btn-secondary {
             background: #95a5a6;
         }

--- a/src/ui.js
+++ b/src/ui.js
@@ -627,14 +627,21 @@ function loadFromFile() {
 export function parseCSV(data) {
     const result = Papa.parse(data, { header: true, skipEmptyLines: true });
 
-    document.getElementById('tasks').innerHTML = '';
-
     const headers = result.meta.fields;
-    for (const row of result.data) {
+    const validRows = result.data.filter(row => {
         const values = headers.map(h => row[h] ?? '');
-        if (values.length >= 8 && values[0]) {
-            addTaskFromData(values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]);
-        }
+        return values.length >= 8 && values[0];
+    });
+
+    if (validRows.length > MAX_TASKS) {
+        alert(`This file contains ${validRows.length} tasks, which exceeds the limit of ${MAX_TASKS}. Please reduce the number of tasks in the file and try again.`);
+        return;
+    }
+
+    document.getElementById('tasks').innerHTML = '';
+    for (const row of validRows) {
+        const values = headers.map(h => row[h] ?? '');
+        addTaskFromData(values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]);
     }
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,8 +5,14 @@ let effortChart = null;
 let timelineChart = null;
 let workloadChart = null;
 
+const MAX_TASKS = 100;
+const MAX_SIMULATIONS = 25000;
+const MAX_PROGRAM_QUANTITY = 100;
+const COMPLEXITY_BUDGET = 5000000;
+
 function addTask() {
     const tasksDiv = document.getElementById('tasks');
+    if (tasksDiv.querySelectorAll('.task-input').length >= MAX_TASKS) return;
     const taskDiv = document.createElement('div');
     taskDiv.className = 'task-input';
     taskDiv.innerHTML = `
@@ -21,10 +27,21 @@ function addTask() {
                 <button class="remove-btn" onclick="removeTask(this)">Remove</button>
             `;
     tasksDiv.appendChild(taskDiv);
+    updateTaskLimitUI();
 }
 
 function removeTask(button) {
     button.parentElement.remove();
+    updateTaskLimitUI();
+}
+
+function updateTaskLimitUI() {
+    const tasksDiv = document.getElementById('tasks');
+    const atLimit = tasksDiv.querySelectorAll('.task-input').length >= MAX_TASKS;
+    const btn = document.getElementById('addTaskBtn');
+    const msg = document.getElementById('taskLimitMessage');
+    if (btn) btn.disabled = atLimit;
+    if (msg) msg.style.display = atLimit ? 'inline' : 'none';
 }
 
 function updateProgress(percentage) {
@@ -37,7 +54,64 @@ function updateProgress(percentage) {
     }
 }
 
+let skipBudgetCheck = false;
+
+function getComplexityOps() {
+    const simulations = parseInt(document.getElementById('simulations').value) || 0;
+    const programQuantity = parseInt(document.getElementById('programQuantity').value) || 0;
+    const taskCount = document.querySelectorAll('.task-input').length;
+    return simulations * programQuantity * taskCount;
+}
+
+function showComplexityWarning(ops) {
+    const warning = document.getElementById('complexityWarning');
+    if (!warning) return;
+    const opsM = (ops / 1000000).toFixed(1);
+    warning.innerHTML = `This configuration (~${opsM}M operations) may take a long time. Reduce simulation runs, program quantity, or tasks — or <button onclick="runAnyway()">Run anyway</button>`;
+    warning.style.display = 'block';
+}
+
+function hideComplexityWarning() {
+    const warning = document.getElementById('complexityWarning');
+    if (warning) warning.style.display = 'none';
+}
+
+function runAnyway() {
+    skipBudgetCheck = true;
+    runSimulation();
+}
+
+function validateInputLimits() {
+    const checks = [
+        { id: 'simulations', max: MAX_SIMULATIONS, errorId: 'simulationsError' },
+        { id: 'programQuantity', max: MAX_PROGRAM_QUANTITY, errorId: 'programQuantityError' },
+    ];
+    let valid = true;
+    for (const { id, max, errorId } of checks) {
+        const input = document.getElementById(id);
+        const errSpan = document.getElementById(errorId);
+        const value = parseInt(input.value);
+        const over = value > max;
+        input.classList.toggle('input-error', over);
+        if (errSpan) errSpan.style.display = over ? 'block' : 'none';
+        if (over) valid = false;
+    }
+    const runButton = document.getElementById('runButton');
+    if (runButton) runButton.disabled = !valid;
+    return valid;
+}
+
 async function runSimulation() {
+    if (!validateInputLimits()) return;
+
+    const ops = getComplexityOps();
+    if (!skipBudgetCheck && ops > COMPLEXITY_BUDGET) {
+        showComplexityWarning(ops);
+        return;
+    }
+    skipBudgetCheck = false;
+    hideComplexityWarning();
+
     const runButton = document.getElementById('runButton');
     const progressContainer = document.getElementById('progressContainer');
 
@@ -51,7 +125,7 @@ async function runSimulation() {
         console.error('Simulation error:', error);
         alert('Simulation encountered an error. Please try again.');
     } finally {
-        runButton.disabled = false;
+        runButton.disabled = !validateInputLimits();
         runButton.textContent = 'Run Timeline & Capacity Simulation';
         progressContainer.style.display = 'none';
     }
@@ -86,6 +160,11 @@ async function runSimulationAsync() {
             });
         }
     });
+
+    if (simulations > MAX_SIMULATIONS || programQuantity > MAX_PROGRAM_QUANTITY) {
+        alert('Simulation parameters exceed allowed limits. Please correct the highlighted fields.');
+        return;
+    }
 
     if (tasks.length === 0) {
         alert('Please add at least one task');
@@ -591,6 +670,7 @@ export function addTaskFromData(name, skipPercentage, workOpt, workExp, workPess
     taskDiv.appendChild(button);
 
     tasksDiv.appendChild(taskDiv);
+    updateTaskLimitUI();
 }
 
 const CSV_EXPORT_HEADERS = ['Task Name', 'Skip %', 'Work Optimistic (hrs)', 'Work Expected (hrs)', 'Work Pessimistic (hrs)', 'Wait Optimistic (days)', 'Wait Expected (days)', 'Wait Pessimistic (days)'];
@@ -631,5 +711,7 @@ function exportToFile() {
 }
 
 window.addEventListener('load', function() {
+    document.getElementById('simulations').addEventListener('input', validateInputLimits);
+    document.getElementById('programQuantity').addEventListener('input', validateInputLimits);
     setTimeout(runSimulation, 500);
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -83,22 +83,25 @@ function runAnyway() {
 
 function validateInputLimits() {
     const checks = [
-        { id: 'simulations', max: MAX_SIMULATIONS, errorId: 'simulationsError' },
-        { id: 'programQuantity', max: MAX_PROGRAM_QUANTITY, errorId: 'programQuantityError' },
+        { id: 'simulations', max: MAX_SIMULATIONS, errorId: 'simulationsError', label: `Simulation runs exceed the maximum of ${MAX_SIMULATIONS.toLocaleString()}` },
+        { id: 'programQuantity', max: MAX_PROGRAM_QUANTITY, errorId: 'programQuantityError', label: `Program quantity exceeds the maximum of ${MAX_PROGRAM_QUANTITY}` },
     ];
-    let valid = true;
-    for (const { id, max, errorId } of checks) {
+    const failures = [];
+    for (const { id, max, errorId, label } of checks) {
         const input = document.getElementById(id);
         const errSpan = document.getElementById(errorId);
         const value = parseInt(input.value);
         const over = value > max;
         input.classList.toggle('input-error', over);
         if (errSpan) errSpan.style.display = over ? 'block' : 'none';
-        if (over) valid = false;
+        if (over) failures.push(label);
     }
     const runButton = document.getElementById('runButton');
-    if (runButton) runButton.disabled = !valid;
-    return valid;
+    if (runButton) {
+        runButton.disabled = failures.length > 0;
+        runButton.title = failures.length > 0 ? failures.join('; ') : '';
+    }
+    return failures.length === 0;
 }
 
 async function runSimulation() {


### PR DESCRIPTION
## Summary

- Adds hard limits on the three variables that determine simulation runtime: 25,000 simulation runs, 100 program quantity, 100 tasks
- Inputs that exceed their limit turn red with an inline error message; the Run button is greyed out and its tooltip names the failing validation
- A 5M-operation advisory budget warning (runs × quantity × tasks) appears as an inline banner with a "Run anyway" option when the threshold is crossed
- CSV imports with more than 100 valid task rows are rejected outright, leaving the existing task list unchanged
- Feature spec added at `docs/features/simulation-complexity-limits.md`

## Test plan

- [ ] Set simulation runs to 25,001 — Run button greyed out, tooltip and inline error visible; correct to 25,000 and button re-enables
- [ ] Set program quantity to 101 — same behaviour; correct and button re-enables
- [ ] Add tasks until the 100th — Add Task button disables with limit message
- [ ] Import a CSV with more than 100 task rows — error shown, existing task list unchanged
- [ ] Set runs = 25,000, quantity = 10, tasks = 20 (5M ops) — budget warning appears, Run still available; click "Run anyway" and simulation proceeds
- [ ] Via DevTools remove the `max` attribute from the simulations input, enter 100,000, click Run — JS validation still blocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)