### PR TITLE
docs: ADR cleanup — amendment notes and gap-filling ADRs 0010–0013

### DIFF
--- a/docs/adr/0001-repository-structure.md
+++ b/docs/adr/0001-repository-structure.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+> **Amended by [ADR-0002: Source Restructuring and Build Step](./0002-source-restructuring-and-build-step.md)**: the structure described here was subsequently revised to add `src/` (simulation and UI source files) and `scripts/` (build tooling) directories. `web/index.html` is now a built artifact assembled from `src/` and is gitignored rather than directly edited.
+>
+> **Amended by [ADR-0003: Property-Based Testing](./0003-property-based-testing.md)**: the adoption of vitest and fast-check introduced a `test/` directory not reflected in the original structure.
+
 ## Context
 
 The repository originally had a flat structure with the main application file (`index.html`) at the root alongside documentation and configuration files. This made it difficult to:

--- a/docs/adr/0003-property-based-testing.md
+++ b/docs/adr/0003-property-based-testing.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+> **Amended by [ADR-0006: happy-dom as the vitest DOM Test Environment](./0006-happy-dom-test-environment.md)**: the Consequences section below refers to `jsdom` as the DOM test environment for `src/ui.js`. ADR-0006 supersedes that detail — `happy-dom` was chosen instead due to its smaller transitive dependency surface and vitest's own recommendation.
+
 ## Context
 
 The application has two distinct areas where testing provides high value, each with characteristics that make example-based unit tests a poor fit:

--- a/docs/adr/0007-rfc4180-csv-compliance.md
+++ b/docs/adr/0007-rfc4180-csv-compliance.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+> **Extended by [ADR-0008: PapaParse as the CSV Library](./0008-papaparse-cdn-dependency.md)**: this ADR mandates RFC 4180 compliance and decides to use a CDN-loaded library, but defers the specific library selection. ADR-0008 records that decision — PapaParse was chosen.
+
 ## Context
 
 The application supports importing and exporting task configurations as CSV files. The current implementation in `src/ui.js` (`parseCSV`, line 548, and the export block, line 613) does not comply with [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180), the de-facto standard for CSV interchange.

--- a/docs/adr/0010-github-ecosystem.md
+++ b/docs/adr/0010-github-ecosystem.md
@@ -1,0 +1,95 @@
+# ADR-0010: GitHub Ecosystem for CI/CD, Automation, and Project Management
+
+## Status
+
+Accepted
+
+> **Supplemented by [ADR-0013: Security Policy and Vulnerability Disclosure](./0013-security-policy.md)**: extends the GitHub ecosystem commitment to include GitHub's native private vulnerability reporting and Security Advisories infrastructure.
+
+## Context
+
+The project is hosted on GitHub and required decisions about CI/CD, automated dependency management, deployment hosting, and code ownership. These concerns could be met by a combination of third-party services (CircleCI, Netlify, Renovate, etc.) or by relying primarily on the tooling GitHub provides natively.
+
+The project's goals favour simplicity and minimal operational overhead: it is a single-file browser application with a small contributor surface and no server-side component.
+
+## Decision
+
+Adopt the GitHub platform's native tooling for all CI/CD and project automation concerns:
+
+- **GitHub Actions** for CI (lint, build, HTML validation, tests), deployment, dependency review, and housekeeping (stale issues)
+- **GitHub Pages** for hosting the built application
+- **Dependabot** for automated dependency update pull requests
+- **CODEOWNERS** (`.github/CODEOWNERS`) to declare code ownership and automatically request reviews
+
+## Rationale
+
+### Single platform reduces operational surface
+
+Using GitHub-native tooling means no additional accounts, credentials, or service integrations to manage. Secrets, permissions, and access controls are all managed in one place. Failures and logs are co-located with the code and pull requests that caused them.
+
+### GitHub Actions is sufficient for the CI workload
+
+The CI pipeline is straightforward: install dependencies, lint, build, validate HTML, run tests. GitHub Actions handles this without any features that would require a more capable CI platform. The free tier for public repositories covers the project's needs entirely.
+
+### GitHub Pages is the natural deployment target
+
+The output is a single static HTML file with no server requirements. GitHub Pages serves static files from a branch or directory with no configuration beyond enabling it in repository settings. This avoids any external hosting dependency.
+
+### Dependabot is zero-configuration for basic coverage
+
+Dependabot monitors `package.json` for npm dependency updates and opens pull requests automatically. The supply chain stance in ADR-0005 (exact pinning, `npm ci --ignore-scripts`, committed lock file) means Dependabot PRs are the primary mechanism for receiving upstream security patches. Enabling it requires only a `.github/dependabot.yml` file — no external service or token.
+
+### CODEOWNERS makes review requirements explicit
+
+A `CODEOWNERS` file declares who is responsible for each part of the repository, enabling GitHub to automatically request reviews from the right people on pull requests. This is a lightweight mechanism that integrates directly with GitHub's PR workflow.
+
+## Consequences
+
+### Positive
+
+- No external service accounts, credentials, or integrations to manage
+- CI results, deployment status, and Dependabot PRs are all visible in the GitHub UI alongside the code
+- GitHub Pages deployment is automatic on merge to `main` with no separate pipeline to maintain
+- Dependabot PRs arrive without any manual polling or scheduling
+
+### Negative
+
+- The project is more tightly coupled to GitHub: migrating to another host (GitLab, Forgejo, etc.) would require replacing all workflows, Dependabot config, and GitHub Pages hosting simultaneously
+- GitHub Actions has usage limits; while the free tier is currently sufficient, a significant increase in CI load could incur cost
+- Dependabot does not cover CDN dependencies (Chart.js, PapaParse) — those are outside its scope and must be managed manually per ADR-0005
+
+## Alternatives Considered
+
+### Alternative 1: Third-party CI (CircleCI, GitHub Actions alternatives)
+
+Use a dedicated CI platform such as CircleCI, Travis CI, or Buildkite.
+
+**Rejected because**: the additional account, credential management, and webhook configuration are not justified for a pipeline this simple. GitHub Actions provides equivalent capability with zero additional service dependencies.
+
+### Alternative 2: Netlify or Vercel for deployment
+
+Use a frontend hosting platform for deployment rather than GitHub Pages.
+
+**Rejected because**: the application is a single static file with no build-time environment variables, preview deployments, or edge functions. GitHub Pages serves this use case with no additional configuration or account. Netlify and Vercel would add an external service dependency for no functional gain.
+
+### Alternative 3: Renovate Bot for dependency updates
+
+Use Renovate as an alternative to Dependabot for automated dependency PRs.
+
+**Rejected because**: Dependabot is built into GitHub and requires no installation or configuration beyond a single YAML file. Renovate offers more flexibility and grouping options but that flexibility is not needed for a project with four npm dev dependencies. Dependabot is the lower-friction choice at this scale.
+
+### Alternative 4: No automated dependency updates
+
+Manage dependency updates manually, triggered by Dependabot alerts or periodic review.
+
+**Rejected because**: ADR-0005 identifies periodic review as a requirement, and Dependabot PRs are the practical mechanism for receiving security patches promptly. Manual-only updates create a lag between a CVE being published and a patch being applied.
+
+## References
+
+- [ADR-0001: Repository Structure Reorganization](./0001-repository-structure.md)
+- [ADR-0003: Property-Based Testing](./0003-property-based-testing.md) — establishes `npm ci --ignore-scripts` and Dependabot as supply chain controls
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md) — Dependabot is cited as a monitoring control
+- [ADR-0009: Pre-commit Application Validation](./0009-precommit-application-validation.md) — local hook complement to GitHub Actions CI
+- [GitHub Actions documentation](https://docs.github.com/en/actions)
+- [GitHub Pages documentation](https://docs.github.com/en/pages)
+- [Dependabot documentation](https://docs.github.com/en/code-security/dependabot)

--- a/docs/adr/0011-precommit-framework.md
+++ b/docs/adr/0011-precommit-framework.md
@@ -1,0 +1,81 @@
+# ADR-0011: pre-commit as the Local Hook Management Framework
+
+## Status
+
+Accepted
+
+## Context
+
+Git provides a hook mechanism for running scripts at defined points in the workflow (before a commit, before a push, etc.). Raw git hooks live in `.git/hooks/` and are not committed to the repository, which means they are not shared between contributors and must be manually installed by each person working on the project.
+
+Several tools exist to manage git hooks declaratively, via a configuration file that is checked into the repository. The project needed local pre-commit validation (see ADR-0009) and required a framework to manage those hooks reliably across contributor environments.
+
+## Decision
+
+Use the **pre-commit** framework (https://pre-commit.com/) to manage git hooks. Hooks are declared in `.pre-commit-config.yaml` at the repository root.
+
+## Rationale
+
+### Declarative, committed configuration
+
+pre-commit stores hook configuration in `.pre-commit-config.yaml`, which is version-controlled alongside the code. Every contributor who installs pre-commit gets the same hooks, at the same versions, without manual setup beyond running `pre-commit install` once.
+
+### Ecosystem of ready-made hooks
+
+pre-commit hosts a public registry of hooks for common tasks. The project uses hooks from this registry for secret detection, trailing whitespace, end-of-file newlines, and merge conflict markers — none of which required custom scripting. This ecosystem is a significant advantage over plain git hooks, which require each check to be scripted from scratch.
+
+### Language-agnostic
+
+pre-commit can run hooks written in any language (Python, Node, Go, shell) and manages their dependencies in isolated environments. This is important for a project that uses both npm tooling (ESLint, vitest) and Python-based hooks from the pre-commit registry, without requiring contributors to manage multiple toolchains manually.
+
+### Pinned hook versions
+
+pre-commit configuration pins each hook to a specific `rev`, and the `pre-commit autoupdate` command provides a controlled upgrade path. This is consistent with the exact-pinning supply chain stance in ADR-0005.
+
+## Consequences
+
+### Positive
+
+- Hook configuration is shared and version-controlled; contributors cannot run without the same checks
+- Ready-made hooks eliminate custom scripting for generic hygiene tasks
+- Hook versions are pinned and auditable
+- Adding new hooks (as in ADR-0009) is a one-line change to `.pre-commit-config.yaml`
+
+### Negative
+
+- Requires contributors to install pre-commit separately (it is a Python tool, not an npm package); the installation step is not automated
+- If pre-commit is not installed, hooks do not run at all — there is no fallback
+- pre-commit manages its own hook environments, which introduces a small additional layer between the hook definition and execution
+
+## Alternatives Considered
+
+### Alternative 1: Plain git hooks
+
+Commit hook scripts to a directory (e.g. `.githooks/`) and document that contributors must run `git config core.hooksPath .githooks` to activate them.
+
+**Rejected because**: there is no enforcement that contributors activate the hooks, no shared version pinning, and no ecosystem of ready-made checks. Each hook must be scripted and maintained in-house.
+
+### Alternative 2: Husky
+
+Husky is an npm package that installs git hooks via npm's `prepare` lifecycle script.
+
+**Rejected because**: Husky runs via `npm install`, which the project explicitly avoids by using `npm ci --ignore-scripts` in CI. An `--ignore-scripts` stance and a `prepare`-script-based hook tool are incompatible. Additionally, Husky hooks are shell scripts without a shared ecosystem of ready-made checks, requiring custom scripting for each task.
+
+### Alternative 3: lefthook
+
+lefthook is a Go-based hook manager with a YAML configuration similar to pre-commit.
+
+**Not adopted**: lefthook is a viable alternative with good performance and no Python dependency. It was not chosen because pre-commit was already in use for generic hygiene hooks before ADR-0009 added application-specific checks, making migration unnecessary.
+
+### Alternative 4: No local hooks — CI only
+
+Rely entirely on GitHub Actions for quality enforcement; do not run checks locally.
+
+**Rejected because**: CI feedback arrives after a push or pull request is opened, not before a commit is created. Local hooks catch failures earlier and avoid avoidable fix commits in the pull request history, as described in ADR-0009.
+
+## References
+
+- [pre-commit documentation](https://pre-commit.com/)
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md) — supply chain stance (pinned versions)
+- [ADR-0009: Pre-commit Application Validation](./0009-precommit-application-validation.md) — application-specific hooks added to this framework
+- [ADR-0010: GitHub Ecosystem](./0010-github-ecosystem.md) — GitHub Actions as the CI complement to local hooks

--- a/docs/adr/0012-openssf-scorecard.md
+++ b/docs/adr/0012-openssf-scorecard.md
@@ -1,0 +1,81 @@
+# ADR-0012: OpenSSF Scorecard for Supply Chain Security Posture Assessment
+
+## Status
+
+Accepted
+
+## Context
+
+The project has several supply chain security controls in place: exact dependency pinning, a committed lock file, `npm ci --ignore-scripts` in CI, Dependabot monitoring, and the dependency decision policy in ADR-0005. These controls address specific risks but provide no aggregate, externally-comparable view of the project's overall security posture.
+
+Without an automated assessment, it is easy for individual controls to degrade over time — branch protection weakened, a dangerous workflow pattern introduced, CI checks removed — without any signal that the posture has regressed.
+
+## Decision
+
+Run the **OpenSSF Scorecard** (https://securityscorecards.dev/) on a weekly schedule via GitHub Actions. Results are published to GitHub's Security tab via the Code Scanning API, making the current score and individual check results visible in the repository alongside other security alerts.
+
+## Rationale
+
+### Industry-standard benchmark
+
+OpenSSF Scorecard assesses projects against a defined set of supply chain security checks, each producing a score from 0–10. The checks cover areas including branch protection, CI presence, dangerous workflow patterns, dependency pinning, binary artefacts, signed releases, and security policy. Using a standard benchmark means the project's posture can be compared against community norms and the criteria are maintained by the security community rather than in-house.
+
+### Automated regression detection
+
+Running Scorecard weekly means a regression (e.g. branch protection accidentally weakened, a new workflow using `pull_request_target` unsafely) surfaces within days rather than being discovered during an audit or incident. The GitHub Code Scanning integration surfaces failures as alerts that can be tracked and closed.
+
+### Complements the manual dependency health criteria in ADR-0005
+
+ADR-0005 defines qualitative health criteria for individual dependencies. Scorecard assesses the project itself as a dependency — how reliably it pins its own dependencies, whether its CI is trustworthy, whether it has a security policy. The two are complementary: ADR-0005 covers what the project consumes; Scorecard covers what the project publishes.
+
+### Learning environment for compliance practices
+
+This project is used as a learning environment to explore what supply chain compliance looks like at the small-project scale. Scorecard makes compliance requirements concrete and measurable, providing hands-on experience with the kinds of automated posture assessments that larger or higher-risk projects are expected to meet. Even where individual checks (signed releases, SLSA provenance) are not currently warranted, seeing their contribution to an overall score makes the trade-offs visible.
+
+### No build artefact or code signing requirement
+
+Scorecard's full set of checks includes signed releases and binary artefacts, which are not applicable to a browser-only project deployed via GitHub Pages. Inapplicable checks score 0 but do not invalidate the rest of the assessment. The checks that matter for this project (branch protection, CI, dangerous workflows, dependency pinning, security policy) all produce meaningful scores.
+
+## Consequences
+
+### Positive
+
+- Automated weekly snapshot of security posture against a defined, community-maintained standard
+- Regressions in branch protection, workflow permissions, or pinning surface as Code Scanning alerts
+- A public Scorecard badge in the README gives contributors and users a quick view of posture
+- No additional tooling account or credential required beyond the GitHub token available to Actions
+- Provides concrete, measurable experience with compliance tooling at the small-project scale
+
+### Negative
+
+- Several checks (signed releases, binary artefacts) are not applicable and will score 0, which depresses the aggregate score without reflecting a real weakness
+- The weekly schedule means a newly introduced regression could exist for up to seven days before detection
+- Scorecard's read-only GitHub token scope means some checks (e.g. branch protection details) must use a token with broader permissions or will report incomplete results
+
+## Alternatives Considered
+
+### Alternative 1: SLSA framework
+
+Implement SLSA (Supply-chain Levels for Software Artifacts) provenance for build artefacts.
+
+**Rejected at this stage**: SLSA focuses on build provenance — proving that a specific artefact was produced by a specific build process. The deployed artefact here is `web/index.html` built by GitHub Actions, but the project has not established a signing or attestation step. SLSA is a meaningful future enhancement but is a heavier lift than Scorecard and addresses a different part of the risk profile.
+
+### Alternative 2: Manual periodic audits only
+
+Assess supply chain security posture manually during periodic dependency reviews (per ADR-0005).
+
+**Rejected because**: manual audits are scheduled and retrospective; they do not detect regressions introduced between review cycles. Scorecard's automated weekly run provides continuous coverage at no marginal cost.
+
+### Alternative 3: No aggregate posture assessment
+
+Rely on individual controls (Dependabot, pinning, `--ignore-scripts`) without an overall posture view.
+
+**Rejected because**: individual controls can degrade silently. An aggregate automated assessment provides a signal when the overall posture regresses, which individual controls do not provide on their own.
+
+## References
+
+- [OpenSSF Scorecard](https://securityscorecards.dev/)
+- [OpenSSF Scorecard GitHub Action](https://github.com/ossf/scorecard-action)
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md) — supply chain stance this complements
+- [ADR-0010: GitHub Ecosystem](./0010-github-ecosystem.md) — GitHub Actions and Code Scanning infrastructure this relies on
+- [ADR-0013: Security Policy and Vulnerability Disclosure](./0013-security-policy.md) — security policy check assessed by Scorecard

--- a/docs/adr/0013-security-policy.md
+++ b/docs/adr/0013-security-policy.md
@@ -1,0 +1,86 @@
+# ADR-0013: Security Policy and Vulnerability Disclosure Process
+
+## Status
+
+Accepted
+
+## Context
+
+The project is a publicly accessible browser application that processes user-supplied CSV data and loads external CDN dependencies. It is hosted on GitHub as a public repository. Without a documented security policy, there is no clear path for a researcher or user who discovers a vulnerability to report it responsibly — the likely outcome is either a public issue (which discloses the vulnerability before a fix is available) or no report at all.
+
+GitHub provides native infrastructure for private vulnerability reporting and coordinated disclosure via its Security Advisories feature.
+
+## Decision
+
+Maintain a `SECURITY.md` file at the repository root documenting:
+
+- Which versions of the application are supported
+- How to report a vulnerability privately (via GitHub's private vulnerability reporting)
+- The expected disclosure timeline (acknowledgement within 48 hours; resolution target within 90 days; coordinated public disclosure)
+
+Use GitHub's native **private vulnerability reporting** as the reporting mechanism. Reporters submit via the repository's Security tab; the report is visible only to repository administrators until a fix is published.
+
+## Rationale
+
+### Standard practice for public repositories
+
+GitHub surfaces `SECURITY.md` automatically in the repository's Security tab and to users who attempt to open a security-related issue. Providing it reduces the chance of accidental public disclosure and signals that the project takes vulnerability reports seriously.
+
+### Private reporting closes the gap between "no process" and "public issue"
+
+Without private reporting, a reporter who discovers a vulnerability in a public GitHub repository has two options: open a public issue (disclosing the vulnerability immediately) or find an email address (if one is published). GitHub's private vulnerability reporting provides a structured, confidential channel that is directly integrated into the repository — no external account, form, or email address required.
+
+### Consistent with the GitHub ecosystem commitment in ADR-0010
+
+ADR-0010 established GitHub's native tooling as the platform for CI/CD, project automation, and dependency management. GitHub's Security Advisories and private vulnerability reporting are part of the same platform. Adopting them here is consistent with that commitment: the project avoids external service dependencies where GitHub provides equivalent capability, and vulnerability management is no exception.
+
+### No external tooling required
+
+GitHub's Security Advisories and private vulnerability reporting are available on all public repositories at no cost. There is no additional service to configure, no webhook to maintain, and no email routing to manage.
+
+### Appropriate to the threat model
+
+The application runs entirely in the browser, processes only locally provided CSV files, and transmits no data to a server. The realistic vulnerability surface is: XSS via CSV import, supply chain compromise via CDN dependencies, or information disclosure via the build process. A lightweight coordinated disclosure process (rather than a formal bug bounty programme) is proportionate to this surface.
+
+## Consequences
+
+### Positive
+
+- Reporters have a clear, confidential path to disclose vulnerabilities without public exposure
+- GitHub indexes `SECURITY.md` and uses it to guide users who file security-adjacent issues
+- The disclosure timeline sets expectations for both reporters and maintainers
+- OpenSSF Scorecard's security-policy check passes (see ADR-0012)
+
+### Negative
+
+- Maintainers are expected to acknowledge reports within 48 hours; this creates an implicit availability commitment
+- A 90-day resolution target may be difficult to meet for complex vulnerabilities if the project is not actively maintained
+- The process relies on GitHub's infrastructure; if GitHub's private reporting feature changes or is removed, an alternative channel would need to be established
+
+## Alternatives Considered
+
+### Alternative 1: Email-based disclosure
+
+Publish a security contact email address in `SECURITY.md` and handle reports via email.
+
+**Rejected because**: email provides no structured intake, no confidential thread visible to all administrators, and no integration with GitHub's advisory publication workflow. GitHub's native reporting is strictly more capable and consistent with ADR-0010's platform stance.
+
+### Alternative 2: No security policy
+
+Omit `SECURITY.md` and rely on reporters opening issues or contacting maintainers through other channels.
+
+**Rejected because**: the absence of a security policy means vulnerabilities are more likely to be disclosed publicly before a fix is available, and OpenSSF Scorecard's security-policy check fails, which signals poor posture to downstream users assessing the project.
+
+### Alternative 3: Third-party bug bounty platform (HackerOne, Bugcrowd)
+
+Use a dedicated vulnerability management platform.
+
+**Rejected because**: bug bounty platforms are designed for programmes with monetary rewards, large researcher communities, and high-volume intake. The overhead of maintaining an external programme is not proportionate to a project of this scale and threat model. It would also introduce an external service dependency that ADR-0010's platform stance specifically avoids.
+
+## References
+
+- [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+- [ADR-0003: Property-Based Testing](./0003-property-based-testing.md) — security properties tested systematically (XSS, injection)
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md) — supply chain risk controls
+- [ADR-0010: GitHub Ecosystem](./0010-github-ecosystem.md) — platform commitment that this ADR's tooling choice is consistent with
+- [ADR-0012: OpenSSF Scorecard](./0012-openssf-scorecard.md) — security-policy check that this ADR satisfies


### PR DESCRIPTION
## Summary

- Adds amendment notices near the top of ADRs 0001, 0003, and 0007 so readers immediately see when a later ADR updated or extended the original decision
- Fills four documentation gaps where significant architectural decisions were in place but had no corresponding ADR

## New ADRs

| ADR | Topic |
|-----|-------|
| 0010 | GitHub ecosystem — Actions, Pages, Dependabot, CODEOWNERS |
| 0011 | pre-commit as the local hook management framework |
| 0012 | OpenSSF Scorecard for supply chain posture assessment |
| 0013 | Security policy and vulnerability disclosure process |

## Amendment notices added

| ADR | Amended/extended by |
|-----|---------------------|
| 0001 Repository Structure | ADR-0002 (src/, scripts/, built web/index.html) and ADR-0003 (test/) |
| 0003 Property-Based Testing | ADR-0006 (happy-dom replaces jsdom reference) |
| 0007 RFC 4180 CSV Compliance | ADR-0008 (PapaParse selected) |
| 0010 GitHub Ecosystem | ADR-0013 (vulnerability reporting infrastructure) |

## Test plan

- [ ] All ADR links resolve correctly
- [ ] Amendment notices render cleanly in GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)