### PR TITLE
feat: prohibit innerHTML with template literals and migrate to DOM API (ADR-0014)

### DIFF
--- a/docs/adr/0014-dom-api-over-innerhtml.md
+++ b/docs/adr/0014-dom-api-over-innerhtml.md
@@ -1,0 +1,95 @@
+# ADR-0014: DOM API over innerHTML for Dynamic Content
+
+## Status
+
+Accepted
+
+## Context
+
+`src/ui.js` currently builds dynamic content by assigning template literals to `element.innerHTML`. This pattern is used in several places: constructing the task input row in `addTask()` (line 18), the complexity warning message in `showComplexityWarning()` (line 70), and the full results display in `displayResults()` (line 295).
+
+The application accepts user-supplied data at multiple points: task names and numeric parameters are entered via form inputs, and task configurations can be imported from arbitrary CSV files. While simulation results are derived values (numbers produced by the engine), the boundary between "safe computed value" and "user-supplied string" is easy to blur as the codebase grows. A task name, for example, is a free-text string that flows directly from user or CSV input. If a task name ever reaches an `innerHTML` assignment — whether directly or via a data structure — it becomes an XSS vector.
+
+The risk is structural: `innerHTML` with template literals is unsafe whenever the interpolated values include any string that originates from outside the application. Because the pattern looks identical whether the value is safe or not, reviewers cannot judge safety by inspection alone. Each usage requires tracing every interpolated expression back to its source.
+
+Current usages in context:
+
+- `addTask()` line 18: static HTML template, no interpolation — currently safe, but establishes the pattern.
+- `showComplexityWarning()` line 70: interpolates `opsM`, a `Number.toFixed()` result — currently safe, but inline `onclick` attribute also bypasses CSP.
+- `displayResults()` line 295: interpolates multiple `data.*` fields derived from simulation output — currently safe, but the same template structure could propagate a task name through `data` in a future change.
+
+## Decision
+
+Dynamic HTML content must be created using the DOM API (`createElement`, `createTextNode`, `appendChild`, `textContent`, `setAttribute`, etc.) rather than by assigning template literals or concatenated strings to `innerHTML` or `outerHTML`.
+
+Rules:
+
+1. **`innerHTML` must not be used with any interpolated value.** Assigning a plain string literal with no `${}` expressions is the only permitted exception (e.g. clearing: `element.innerHTML = ''`).
+2. **Event handlers must be attached via `addEventListener`.** Inline `onclick` attributes in template literals bypass Content Security Policy and mix markup with behaviour.
+3. **User-supplied strings must be set via `textContent`.** Setting `.textContent` on an element is always safe regardless of string content — the browser never interprets it as markup.
+
+## Rationale
+
+### innerHTML with interpolation is structurally unsafe
+
+The browser parses the entire string passed to `innerHTML` as HTML. Any `<`, `>`, `"`, `'`, or `&` character in an interpolated value can break out of the intended context and introduce executable content. Correct escaping requires explicit effort on every interpolation; a single omission is a vulnerability. The DOM API avoids the problem entirely: `textContent` treats its argument as a plain string; there is nothing to escape and no parse step.
+
+### The risk scales with codebase growth
+
+At present, no user-supplied string reaches an `innerHTML` assignment. That is a property of the current call graph, not a property of the pattern. As features are added — richer results, task summaries, named scenarios — the likelihood of a user string flowing into a template literal grows. Prohibiting the pattern now costs less than auditing every future change for XSS exposure.
+
+### DOM API code is more maintainable
+
+Template literals that construct HTML are opaque: the structure is only visible at runtime, attributes are strings prone to typos, and dynamic behaviour requires parsing the rendered output or tracing strings. DOM API code makes structure explicit and keeps each concern (element creation, content, attributes, events) in a separate, testable expression.
+
+### Consistency with the threat model in ADR-0013
+
+ADR-0013 identifies XSS via CSV import as a realistic vulnerability surface. Prohibiting `innerHTML` with interpolation is the structural control that prevents this class of vulnerability, complementing the coordinated disclosure process that ADR-0013 establishes.
+
+## Consequences
+
+### Positive
+
+- User-supplied strings cannot cause XSS regardless of their content — the DOM API never interprets them as markup.
+- Reviewers can identify unsafe DOM manipulation by a single rule (`innerHTML` with `${}`) without tracing data flow.
+- Inline `onclick` attributes are eliminated, enabling a stricter Content Security Policy in future.
+- New contributors cannot accidentally introduce XSS by following existing examples.
+
+### Negative
+
+- Existing `innerHTML` usages in `src/ui.js` (lines 18, 70, 295) must be migrated to the DOM API. The `displayResults()` block at line 295 is substantial and will require meaningful refactoring effort.
+- DOM API code for complex structures is more verbose than equivalent template literals. Introducing helper utilities (e.g. a small `createElement` wrapper) may be warranted to manage the verbosity.
+
+## Alternatives Considered
+
+### Alternative 1: Escape interpolated values before insertion
+
+Use an HTML-escaping utility on every interpolated expression before assigning to `innerHTML`.
+
+**Rejected because**: this requires correct application on every interpolation in every template — a per-usage discipline rather than a structural guarantee. A single missed escape re-opens the vulnerability. The DOM API makes the safe path the default path.
+
+### Alternative 2: Trusted Types API
+
+Use the browser's Trusted Types API to enforce that only explicitly constructed `TrustedHTML` objects can be assigned to `innerHTML`.
+
+**Rejected because**: Trusted Types requires a Content Security Policy header, which this application cannot deliver as a file served without a web server. It is also not yet universally supported. It could complement the DOM API approach in a future deployment context but cannot replace it here.
+
+### Alternative 3: DOMParser / document fragment from string
+
+Parse template literals into a `DocumentFragment` via `DOMParser` and insert the fragment.
+
+**Rejected because**: parsing user-supplied strings through `DOMParser` retains the same XSS risk as `innerHTML` — the parser executes any markup in the input. It solves nothing.
+
+### Alternative 4: Sanitize strings with DOMPurify
+
+Load a sanitization library and pass all `innerHTML` assignments through it.
+
+**Rejected because**: sanitization is defence-in-depth, not a primary control. It introduces a CDN dependency (inconsistent with ADR-0005's bar for new dependencies) and relies on the sanitizer being correctly applied everywhere. The DOM API removes the attack surface; sanitization only reduces it.
+
+## References
+
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [MDN: Node.textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
+- [MDN: Trusted Types API](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API)
+- [ADR-0013: Security Policy and Vulnerability Disclosure Process](./0013-security-policy.md) — threat model that identifies XSS as a realistic risk
+- [ADR-0005: Dependency Decision Policy](./0005-dependency-decision-policy.md) — bar for new CDN dependencies

--- a/src/ui.js
+++ b/src/ui.js
@@ -15,17 +15,32 @@ function addTask() {
     if (tasksDiv.querySelectorAll('.task-input').length >= MAX_TASKS) return;
     const taskDiv = document.createElement('div');
     taskDiv.className = 'task-input';
-    taskDiv.innerHTML = `
-                <input type="text" placeholder="Task name">
-                <input type="number" placeholder="Skip %" min="0" max="95" step="5" value="0" title="% chance task can be skipped">
-                <input type="number" placeholder="Work Opt" min="0.1" step="0.1" title="Work effort optimistic (hours)">
-                <input type="number" placeholder="Work Exp" min="0.1" step="0.1" title="Work effort expected (hours)">
-                <input type="number" placeholder="Work Pess" min="0.1" step="0.1" title="Work effort pessimistic (hours)">
-                <input type="number" placeholder="Wait Opt" min="0" step="0.1" value="0" title="Wait time optimistic">
-                <input type="number" placeholder="Wait Exp" min="0" step="0.1" value="0" title="Wait time expected">
-                <input type="number" placeholder="Wait Pess" min="0" step="0.1" value="0" title="Wait time pessimistic">
-                <button class="remove-btn" onclick="removeTask(this)">Remove</button>
-            `;
+
+    const inputSpecs = [
+        { type: 'text',   placeholder: 'Task name' },
+        { type: 'number', placeholder: 'Skip %',    min: '0',   max: '95', step: '5',  value: '0', title: '% chance task can be skipped' },
+        { type: 'number', placeholder: 'Work Opt',  min: '0.1', step: '0.1', title: 'Work effort optimistic (hours)' },
+        { type: 'number', placeholder: 'Work Exp',  min: '0.1', step: '0.1', title: 'Work effort expected (hours)' },
+        { type: 'number', placeholder: 'Work Pess', min: '0.1', step: '0.1', title: 'Work effort pessimistic (hours)' },
+        { type: 'number', placeholder: 'Wait Opt',  min: '0',   step: '0.1', value: '0', title: 'Wait time optimistic' },
+        { type: 'number', placeholder: 'Wait Exp',  min: '0',   step: '0.1', value: '0', title: 'Wait time expected' },
+        { type: 'number', placeholder: 'Wait Pess', min: '0',   step: '0.1', value: '0', title: 'Wait time pessimistic' },
+    ];
+
+    for (const attrs of inputSpecs) {
+        const input = document.createElement('input');
+        for (const [attr, val] of Object.entries(attrs)) {
+            input.setAttribute(attr, val);
+        }
+        taskDiv.appendChild(input);
+    }
+
+    const button = document.createElement('button');
+    button.className = 'remove-btn';
+    button.textContent = 'Remove';
+    button.addEventListener('click', function() { removeTask(this); });
+    taskDiv.appendChild(button);
+
     tasksDiv.appendChild(taskDiv);
     updateTaskLimitUI();
 }
@@ -67,7 +82,13 @@ function showComplexityWarning(ops) {
     const warning = document.getElementById('complexityWarning');
     if (!warning) return;
     const opsM = (ops / 1000000).toFixed(1);
-    warning.innerHTML = `This configuration (~${opsM}M operations) may take a long time. Reduce simulation runs, program quantity, or tasks — or <button onclick="runAnyway()">Run anyway</button>`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Run anyway';
+    btn.addEventListener('click', runAnyway);
+    warning.replaceChildren(
+        document.createTextNode(`This configuration (~${opsM}M operations) may take a long time. Reduce simulation runs, program quantity, or tasks — or `),
+        btn
+    );
     warning.style.display = 'block';
 }
 
@@ -271,134 +292,115 @@ async function runSimulationAsync() {
     });
 }
 
+function el(tag, className, ...children) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    for (const child of children) {
+        node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    }
+    return node;
+}
+
+function metric(value, label) {
+    return el('div', 'metric',
+        el('div', 'metric-value', value),
+        el('div', 'metric-label', label)
+    );
+}
+
+function scenarioItem(label, value) {
+    return el('div', 'scenario-item',
+        el('span', 'scenario-label', label),
+        el('span', 'scenario-value', value)
+    );
+}
+
+function buildCapacityMessage(overCapacityPercent) {
+    const isHigh = overCapacityPercent > 20;
+    const isMod = overCapacityPercent > 5;
+    const strong = document.createElement('strong');
+    let suffix;
+    if (isHigh) {
+        strong.textContent = '⚠️ Capacity Risk:';
+        suffix = ` ${overCapacityPercent}% chance of exceeding available hours. Consider reducing scope or increasing capacity.`;
+    } else if (isMod) {
+        strong.textContent = '⚠️ Moderate Risk:';
+        suffix = ` ${overCapacityPercent}% chance of exceeding available hours. Monitor closely and have contingency plans.`;
+    } else {
+        strong.textContent = '✅ Good Capacity:';
+        suffix = ` Only ${overCapacityPercent}% chance of exceeding available hours. Reasonable buffer for unexpected work.`;
+    }
+    return el('div', isHigh || isMod ? 'capacity-warning' : 'capacity-good', strong, suffix);
+}
+
 function displayResults(data) {
     const resultsDiv = document.getElementById('results');
 
-    let capacityMessage = '';
-    if (data.overCapacityPercent > 20) {
-        capacityMessage = `<div class="capacity-warning">
-                    <strong>⚠️ Capacity Risk:</strong> ${data.overCapacityPercent}% chance of exceeding available hours.
-                    Consider reducing scope or increasing capacity.
-                </div>`;
-    } else if (data.overCapacityPercent > 5) {
-        capacityMessage = `<div class="capacity-warning">
-                    <strong>⚠️ Moderate Risk:</strong> ${data.overCapacityPercent}% chance of exceeding available hours.
-                    Monitor closely and have contingency plans.
-                </div>`;
-    } else {
-        capacityMessage = `<div class="capacity-good">
-                    <strong>✅ Good Capacity:</strong> Only ${data.overCapacityPercent}% chance of exceeding available hours.
-                    Reasonable buffer for unexpected work.
-                </div>`;
-    }
+    const riskLevel = data.overCapacityPercent > 20 ? 'high' : data.overCapacityPercent > 5 ? 'medium' : 'low';
+    const riskLabel = data.overCapacityPercent > 20 ? 'High' : data.overCapacityPercent > 5 ? 'Moderate' : 'Low';
+    const avgWeeklyHours = (data.workloadData.totalHours / data.workloadData.maxWeek).toFixed(1);
+    const peakHours = Math.max(...data.workloadData.weeklyHours).toFixed(1);
 
-    resultsDiv.innerHTML = `
-                <div class="results">
-                    <h3>Simulation Results</h3>
+    const effortCanvas = document.createElement('canvas');
+    effortCanvas.id = 'effortChart';
+    const timelineCanvas = document.createElement('canvas');
+    timelineCanvas.id = 'timelineChart';
+    const workloadCanvas = document.createElement('canvas');
+    workloadCanvas.id = 'workloadChart';
 
-                    <h4>Effort Analysis (person-hours)</h4>
-                    <div class="results-grid">
-                        <div class="metric">
-                            <div class="metric-value">${data.effort.mean}</div>
-                            <div class="metric-label">Mean Effort (hrs)</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.effort.p50}</div>
-                            <div class="metric-label">Median (P50) hrs</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.effort.confidenceValue}</div>
-                            <div class="metric-label">${data.confidence}% Confidence (hrs)</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.effort.p90}</div>
-                            <div class="metric-label">P90 (Worst Case) hrs</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.capacity}</div>
-                            <div class="metric-label">Available Capacity (hrs)</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.overCapacityPercent}%</div>
-                            <div class="metric-label">Over Capacity Risk</div>
-                        </div>
-                    </div>
-                    ${capacityMessage}
+    const workloadHeading = document.createElement('h4');
+    workloadHeading.textContent = `Weekly Workload (${data.confidence}% Confidence Case - ${data.workloadData.simulationCount} simulations)`;
 
-                    <h4>Timeline Analysis (days)</h4>
-                    <div class="results-grid">
-                        <div class="metric">
-                            <div class="metric-value">${data.timeline.mean}</div>
-                            <div class="metric-label">Mean Timeline</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.timeline.p50}</div>
-                            <div class="metric-label">Median (P50)</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.timeline.confidenceValue}</div>
-                            <div class="metric-label">${data.confidence}% Confidence</div>
-                        </div>
-                        <div class="metric">
-                            <div class="metric-value">${data.timeline.p90}</div>
-                            <div class="metric-label">P90 (Worst Case)</div>
-                        </div>
-                    </div>
+    const riskValueSpan = el('span', `scenario-value risk-${riskLevel}`,
+        `${riskLabel} (${data.overCapacityPercent}% chance of exceeding capacity)`
+    );
 
-                    <div class="distribution-chart">
-                        <canvas id="effortChart"></canvas>
-                    </div>
+    const container = el('div', 'results',
+        el('h3', null, 'Simulation Results'),
+        el('h4', null, 'Effort Analysis (person-hours)'),
+        el('div', 'results-grid',
+            metric(data.effort.mean, 'Mean Effort (hrs)'),
+            metric(data.effort.p50, 'Median (P50) hrs'),
+            metric(data.effort.confidenceValue, `${data.confidence}% Confidence (hrs)`),
+            metric(data.effort.p90, 'P90 (Worst Case) hrs'),
+            metric(String(data.capacity), 'Available Capacity (hrs)'),
+            metric(`${data.overCapacityPercent}%`, 'Over Capacity Risk')
+        ),
+        buildCapacityMessage(data.overCapacityPercent),
+        el('h4', null, 'Timeline Analysis (days)'),
+        el('div', 'results-grid',
+            metric(data.timeline.mean, 'Mean Timeline'),
+            metric(data.timeline.p50, 'Median (P50)'),
+            metric(data.timeline.confidenceValue, `${data.confidence}% Confidence`),
+            metric(data.timeline.p90, 'P90 (Worst Case)')
+        ),
+        el('div', 'distribution-chart', effortCanvas),
+        el('div', 'distribution-chart', timelineCanvas),
+        workloadHeading,
+        el('div', 'distribution-chart', workloadCanvas),
+        el('div', 'executive-summary',
+            el('h3', null, 'Executive Summary'),
+            el('div', 'summary-grid',
+                el('div', 'summary-card',
+                    el('h4', null, 'Planning Scenarios'),
+                    scenarioItem('Most Likely Outcome:', `${data.effort.p50} hours over ${data.timeline.p50} business days`),
+                    scenarioItem('Conservative Planning:', `${data.effort.confidenceValue} hours over ${data.timeline.confidenceValue} business days`),
+                    scenarioItem('Contingency Planning:', `${data.effort.p90} hours over ${data.timeline.p90} business days`)
+                ),
+                el('div', 'summary-card',
+                    el('h4', null, 'Resource Requirements'),
+                    scenarioItem('Expected Weekly Capacity:', `${avgWeeklyHours} hours/week`),
+                    scenarioItem('Peak Weekly Demand:', `${peakHours} hours`),
+                    el('div', 'scenario-item',
+                        el('span', 'scenario-label', 'Capacity Risk Level:'),
+                        riskValueSpan
+                    )
+                )
+            )
+        )
+    );
 
-                    <div class="distribution-chart">
-                        <canvas id="timelineChart"></canvas>
-                    </div>
-
-                    <h4>Weekly Workload (${data.confidence}% Confidence Case - ${data.workloadData.simulationCount} simulations)</h4>
-                    <div class="distribution-chart">
-                        <canvas id="workloadChart"></canvas>
-                    </div>
-
-                    <div class="executive-summary">
-                        <h3>Executive Summary</h3>
-                        <div class="summary-grid">
-                            <div class="summary-card">
-                                <h4>Planning Scenarios</h4>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Most Likely Outcome:</span>
-                                    <span class="scenario-value">${data.effort.p50} hours over ${data.timeline.p50} business days</span>
-                                </div>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Conservative Planning:</span>
-                                    <span class="scenario-value">${data.effort.confidenceValue} hours over ${data.timeline.confidenceValue} business days</span>
-                                </div>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Contingency Planning:</span>
-                                    <span class="scenario-value">${data.effort.p90} hours over ${data.timeline.p90} business days</span>
-                                </div>
-                            </div>
-
-                            <div class="summary-card">
-                                <h4>Resource Requirements</h4>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Expected Weekly Capacity:</span>
-                                    <span class="scenario-value">${(data.workloadData.totalHours / data.workloadData.maxWeek).toFixed(1)} hours/week</span>
-                                </div>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Peak Weekly Demand:</span>
-                                    <span class="scenario-value">${Math.max(...data.workloadData.weeklyHours).toFixed(1)} hours</span>
-                                </div>
-                                <div class="scenario-item">
-                                    <span class="scenario-label">Capacity Risk Level:</span>
-                                    <span class="scenario-value risk-${data.overCapacityPercent > 20 ? 'high' : data.overCapacityPercent > 5 ? 'medium' : 'low'}">
-                                        ${data.overCapacityPercent > 20 ? 'High' : data.overCapacityPercent > 5 ? 'Moderate' : 'Low'} (${data.overCapacityPercent}% chance of exceeding capacity)
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
-
+    resultsDiv.replaceChildren(container);
     resultsDiv.style.display = 'block';
     createCharts(data.effortResults, data.timelineResults, data.capacity, data.workloadData);
 }


### PR DESCRIPTION
## Summary

- Adds ADR-0014 establishing the rule that dynamic HTML must be built with the DOM API (`createElement`, `textContent`, `addEventListener`) rather than assigning template literals to `innerHTML`
- Migrates all three violations in `src/ui.js` to conform: `addTask()`, `showComplexityWarning()`, and the large `displayResults()` block
- Introduces a small `el()` helper and supporting utilities (`metric`, `scenarioItem`, `buildCapacityMessage`) to keep the refactored `displayResults()` readable

## Motivation

`innerHTML` with interpolated values is structurally unsafe: any string that originates from user input or CSV import and reaches an assignment is an XSS vector. The pattern is indistinguishable by inspection from safe usage, so every future change requires tracing data flow to assess safety. The DOM API makes user strings safe by construction — `textContent` never parses its argument as markup.

The realistic XSS surface identified in ADR-0013 includes CSV import; a task name is a free-text string that flows through the same data structures used to render results. This change removes the structural precondition for that vulnerability.

## Changes

| File | Change |
|------|--------|
| `docs/adr/0014-dom-api-over-innerhtml.md` | New ADR documenting the decision, rationale, and alternatives |
| `src/ui.js` | `addTask()` — DOM API replacing static template + inline `onclick` |
| `src/ui.js` | `showComplexityWarning()` — `replaceChildren()` + `addEventListener` replacing interpolated `innerHTML` |
| `src/ui.js` | `displayResults()` — full rewrite using `el()`/`metric()`/`scenarioItem()`/`buildCapacityMessage()` helpers |

The one permitted exception per ADR-0014 — `innerHTML = ''` for clearing — remains on line 646.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] ESLint clean (`npx eslint src/simulation.js src/ui.js`)
- [ ] HTML validation passes (`npx html-validate web/index.html`)
- [ ] All 26 tests pass (`npm test`)
- [ ] Manual smoke test: open `web/index.html`, run a simulation, verify results display and charts render correctly
- [ ] Manual test: add and remove tasks via the UI
- [ ] Manual test: trigger the complexity warning and confirm "Run anyway" works
- [ ] Manual test: CSV import with task names containing `<`, `>`, `"`, and `&` — verify they render as plain text, not markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)