### PR TITLE
feat: add Content-Security-Policy meta tag via build step

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const root = path.join(__dirname, '..');
 const template = fs.readFileSync(path.join(root, 'src/template.html'), 'utf8');
@@ -15,7 +16,22 @@ function stripModuleSyntax(code) {
 }
 
 const js = stripModuleSyntax(simulation) + '\n' + stripModuleSyntax(ui);
-const output = template.replace('/* @@BUILD_JS@@ */', js);
+let output = template.replace('/* @@BUILD_JS@@ */', js);
+
+// Hash the inline script content (text between <script> and </script> after substitution)
+const scriptContent = '\n' + js + '\n    ';
+const scriptHash = crypto.createHash('sha256').update(scriptContent, 'utf8').digest('base64');
+
+const csp = [
+    "default-src 'none'",
+    `script-src 'sha256-${scriptHash}' https://cdnjs.cloudflare.com`,
+    "style-src 'unsafe-inline'",
+    "img-src data: blob:",
+    "base-uri 'none'",
+    "form-action 'none'",
+].join('; ');
+
+output = output.replace('<!-- @@CSP@@ -->', `<meta http-equiv="Content-Security-Policy" content="${csp}">`);
 
 const outputPath = path.join(root, 'web/index.html');
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });

--- a/src/template.html
+++ b/src/template.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- @@CSP@@ -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Monte Carlo Timeline &amp; Capacity Planning</title>


### PR DESCRIPTION
## Summary

- Adds a `<!-- @@CSP@@ -->` placeholder to `src/template.html`
- Updates `scripts/build.js` to compute a SHA-256 hash of the injected inline script at build time and substitute the placeholder with a `<meta http-equiv="Content-Security-Policy">` tag
- Policy: `default-src 'none'`, script execution restricted to the hashed inline bundle and `cdnjs.cloudflare.com` (Chart.js + PapaParse), inline styles permitted, images from `data:` and `blob:` only, `base-uri` and `form-action` locked to `'none'`
- The hash is recomputed on every build, so it stays correct automatically as the JS source changes

## Test plan

- [ ] Run `npm run build` and confirm the CSP meta tag appears at the top of `<head>` in `web/index.html`
- [ ] Open `web/index.html` in a browser, run a simulation, and confirm no CSP violations in the console
- [ ] Confirm charts render and CSV import/export work (CDN scripts unblocked by the `cdnjs.cloudflare.com` allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)