### PR TITLE
chore: remove stray console.log and console.warn debug calls

### DIFF
--- a/src/simulation.js
+++ b/src/simulation.js
@@ -215,7 +215,6 @@ export function scheduleWorkItem(item, weeklyUsage, weeklyCapacity, hoursPerDay)
     }
 
     if (attempts >= maxAttempts) {
-        console.warn(`Task '${item.task}' could not be scheduled within capacity constraints: requires ${item.hours} hours. Forcing schedule.`);
         allocateCapacity(startDay, workDays, item.hours, weeklyUsage);
     }
 
@@ -286,19 +285,10 @@ export function findConfidenceRangeSimulations(simulationData, confidenceTimelin
     const endIndex = Math.min(simulationData.length - 1, startIndex + rangeSize - 1);
     const rangeSimulations = simulationData.slice(startIndex, endIndex + 1);
 
-    console.log('Confidence Range:', {
-        targetIndex: confidenceIndex,
-        rangeStart: startIndex,
-        rangeEnd: endIndex,
-        simulationsUsed: rangeSimulations.length,
-        timelineRange: `${rangeSimulations[0]?.timeline.toFixed(1)} - ${rangeSimulations[rangeSimulations.length-1]?.timeline.toFixed(1)} days`,
-        effortRange: `${Math.min(...rangeSimulations.map(s => s.effort)).toFixed(1)} - ${Math.max(...rangeSimulations.map(s => s.effort)).toFixed(1)} hours`
-    });
-
     return rangeSimulations;
 }
 
-export function calculateAggregatedWorkloadDistribution(confidenceSimulations, confidence, weeklyCapacity, debugInfo) {
+export function calculateAggregatedWorkloadDistribution(confidenceSimulations, confidence, weeklyCapacity) {
     if (!confidenceSimulations || confidenceSimulations.length === 0) {
         return { weeklyHours: [], maxWeek: 0, weeklyCapacity: weeklyCapacity, simulationCount: 0 };
     }
@@ -325,11 +315,6 @@ export function calculateAggregatedWorkloadDistribution(confidenceSimulations, c
     );
 
     const totalWorkloadHours = weeklyHours.reduce((sum, hours) => sum + hours, 0);
-    console.log('Workload Total Check:', {
-        weeklyHoursSum: totalWorkloadHours.toFixed(1),
-        targetEffort: debugInfo.averageEffort,
-        difference: (totalWorkloadHours - parseFloat(debugInfo.averageEffort)).toFixed(1)
-    });
 
     return {
         weeklyHours: weeklyHours,

--- a/src/ui.js
+++ b/src/ui.js
@@ -254,18 +254,7 @@ async function runSimulationAsync() {
 
     const confidenceSimulations = findConfidenceRangeSimulations(simulationData, timelineConfidenceValue, confidence);
 
-    const debugInfo = {
-        targetTimeline: timelineConfidenceValue,
-        targetEffort: effortConfidenceValue,
-        actualSimulations: confidenceSimulations.map(s => ({
-            effort: s.effort.toFixed(1),
-            timeline: s.timeline.toFixed(1)
-        })),
-        averageEffort: (confidenceSimulations.reduce((sum, s) => sum + s.effort, 0) / confidenceSimulations.length).toFixed(1)
-    };
-    console.log('Workload Debug:', debugInfo);
-
-    const workloadData = calculateAggregatedWorkloadDistribution(confidenceSimulations, confidence, weeklyCapacity, debugInfo);
+    const workloadData = calculateAggregatedWorkloadDistribution(confidenceSimulations, confidence, weeklyCapacity);
 
     displayResults({
         effort: {


### PR DESCRIPTION
## Summary

- Removes 3 `console.log` calls and 1 `console.warn` left over from debugging workload scheduling and confidence range calculations
- Drops the now-unused `debugInfo` object in `ui.js` and the corresponding `debugInfo` parameter from `calculateAggregatedWorkloadDistribution` in `simulation.js`

## Test plan

- [ ] All 26 unit tests pass (`npm test`)
- [ ] ESLint clean (`npx eslint src/simulation.js src/ui.js`)
- [ ] HTML validates (`npx html-validate web/index.html`)
- [ ] No console output in browser DevTools when running a simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)