### PR TITLE
fix: clamp Math.random() in normalRandom() to prevent Infinity on zero

### DIFF
--- a/src/simulation.js
+++ b/src/simulation.js
@@ -38,7 +38,7 @@ export function gammaRandom(shape) {
 
 export function normalRandom() {
     // Box-Muller transform
-    const u = Math.random();
+    const u = Math.random() || Number.MIN_VALUE;
     const v = Math.random();
     return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
 }


### PR DESCRIPTION
## Summary

- `normalRandom()` uses the Box-Muller transform: `Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v)`
- If `Math.random()` returns exactly `0`, `Math.log(0) = -Infinity`, producing `Infinity` as the result
- Fix clamps `u` to `Number.MIN_VALUE` using `|| Number.MIN_VALUE` — the same pattern already used in `gammaRandom()` for the same reason

## Test plan

- [ ] All 26 existing tests pass (`npm test`)
- [ ] ESLint clean (`npx eslint src/simulation.js src/ui.js`)
- [ ] HTML validation clean (`npx html-validate web/index.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)