### PR TITLE
feat: pin CSP script-src to SRI hashes instead of CDN host

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,9 +22,14 @@ let output = template.replace('/* @@BUILD_JS@@ */', js);
 const scriptContent = '\n' + js + '\n    ';
 const scriptHash = crypto.createHash('sha256').update(scriptContent, 'utf8').digest('base64');
 
+// Extract SRI hashes from external <script integrity="..."> tags so the CSP
+// pins exact file content rather than allowing the whole CDN host.
+const externalScriptHashes = [...template.matchAll(/<script[^>]+integrity="([^"]+)"/g)]
+    .map(m => `'${m[1]}'`);
+
 const csp = [
     "default-src 'none'",
-    `script-src 'sha256-${scriptHash}' https://cdnjs.cloudflare.com`,
+    `script-src 'sha256-${scriptHash}' ${externalScriptHashes.join(' ')}`,
     "style-src 'unsafe-inline'",
     "img-src data: blob:",
     "base-uri 'none'",


### PR DESCRIPTION
## Summary

- Removes `https://cdnjs.cloudflare.com` from `script-src`, replacing it with the exact `sha512` hash sources already present in the `integrity` attributes on the Chart.js and PapaParse `<script>` tags
- The browser now rejects any script whose content doesn't match the pinned hash, even if it's served from the correct host
- Hashes are extracted dynamically from `template.html` at build time — bumping a library version automatically updates the CSP with no extra step

## Test plan

- [x] `npm run build` succeeds and the generated CSP contains `sha512-Y51n9m...` (Chart.js) and `sha512-dfX5uY...` (PapaParse) with no CDN host entry
- [x] `npx html-validate web/index.html` passes
- [x] `npm test` — 52 tests pass
- [ ] Open `web/index.html` in browser, run a simulation — no CSP violations in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)