### PR TITLE
fix: reset skipBudgetCheck before validateInputLimits early return

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -126,14 +126,16 @@ function validateInputLimits() {
 }
 
 async function runSimulation() {
+    const bypassBudget = skipBudgetCheck;
+    skipBudgetCheck = false;
+
     if (!validateInputLimits()) return;
 
     const ops = getComplexityOps();
-    if (!skipBudgetCheck && ops > COMPLEXITY_BUDGET) {
+    if (!bypassBudget && ops > COMPLEXITY_BUDGET) {
         showComplexityWarning(ops);
         return;
     }
-    skipBudgetCheck = false;
     hideComplexityWarning();
 
     const runButton = document.getElementById('runButton');


### PR DESCRIPTION
## Summary

- `skipBudgetCheck` was only reset at the point _after_ both the `validateInputLimits()` and complexity-budget checks passed
- If `validateInputLimits()` returned false (e.g. user entered an over-limit value), `runSimulation()` returned early and left `skipBudgetCheck = true` stranded
- On the next run — after the user corrected the input — the complexity budget check was silently bypassed

Fix: capture the flag into `bypassBudget` and reset `skipBudgetCheck = false` unconditionally at entry, before any early return.

## Test plan

- [ ] Set simulations and program quantity within limits, with a config that would exceed `COMPLEXITY_BUDGET` → complexity warning shown
- [ ] Click "Run anyway" → `skipBudgetCheck` set true, simulation runs
- [ ] Set simulations over `MAX_SIMULATIONS` → Run button disabled; `skipBudgetCheck` is not strandable here (button is disabled)
- [ ] Trigger complexity warning → click "Run anyway" → immediately set simulations over limit → correct the value → click Run: confirm complexity warning appears again (budget check not bypassed)
- [ ] `npm test` passes (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)