### PR TITLE
docs: introduce feature documentation structure and foundation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,17 @@ This directory contains comprehensive documentation for the Monte Carlo Capacity
 
 ## Quick Navigation
 
+**New to this project? Start with [Foundation](foundation.md)** — it explains the planning problem the tool addresses and the reasoning behind the model.
+
 ### For Users
 
+- **[Foundation](foundation.md)**: The conceptual model — why the tool works the way it does
 - **[Main README](../README.md)**: Getting started and basic usage
 - **[Security Policy](development/SECURITY.md)**: Security considerations and vulnerability reporting
 
 ### For Contributors
 
+- **[Foundation](foundation.md)**: Start here to understand the design intent
 - **[Contributing Guide](development/CONTRIBUTING.md)**: How to contribute to this project
 - **[Security Policy](development/SECURITY.md)**: Security considerations for development
 
@@ -24,6 +28,7 @@ This directory contains comprehensive documentation for the Monte Carlo Capacity
 ```text
 docs/
 ├── README.md                    # This navigation file
+├── foundation.md                # Start here: the planning problem and conceptual model
 ├── adr/                         # Architecture Decision Records
 │   └── template.md             # ADR template for new decisions
 ├── features/                    # Feature-specific documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,18 @@ This directory contains comprehensive documentation for the Monte Carlo Capacity
 ```text
 docs/
 ├── README.md                    # This navigation file
-├── adr/                        # Architecture Decision Records
-│   ├── template.md            # ADR template for new decisions
-│   └── 0001-repository-structure.md
-├── features/                   # Feature-specific documentation
-│   └── template.md            # Template for documenting features
-└── development/               # Development and maintenance docs
-    ├── CONTRIBUTING.md        # Contribution guidelines
-    └── SECURITY.md           # Security policy and procedures
+├── adr/                         # Architecture Decision Records
+│   └── template.md             # ADR template for new decisions
+├── features/                    # Feature-specific documentation
+│   ├── template.md             # Template for documenting features
+│   ├── 01-configure/           # Input definition: tasks and simulation parameters
+│   ├── 02-simulate/            # Simulation computation and guards
+│   ├── 03-report/              # Results display and visualisation
+│   ├── 04-exchange/            # CSV import and export
+│   └── 90-testing/             # Cross-cutting quality and verification concerns
+└── development/                 # Development and maintenance docs
+    ├── CONTRIBUTING.md         # Contribution guidelines
+    └── SECURITY.md             # Security policy and procedures
 ```
 
 ## Documentation Standards

--- a/docs/adr/0015-feature-documentation-structure.md
+++ b/docs/adr/0015-feature-documentation-structure.md
@@ -1,0 +1,72 @@
+# ADR-0015: Feature Documentation Structure
+
+## Status
+
+Accepted
+
+## Context
+
+The `docs/features/` directory contains a template and three feature documents, but no organising principle. As the feature documentation grows toward full coverage of the application, an unstructured flat directory becomes hard to navigate and gives a reader no sense of how features relate to each other or to the user workflow.
+
+The three existing documents cover concerns at very different levels of abstraction — a simulation guard (complexity limits), a test infrastructure decision (property-based testing), and a security property (DOM injection prevention) — without any grouping that signals their relationship to the running application.
+
+A reader trying to understand the application as a whole, or to regenerate a similar application from the documentation, needs a structure that reflects the conceptual architecture, not the implementation file layout.
+
+## Decision
+
+Feature documentation is organised into numbered subdirectories that reflect the application's workflow phases:
+
+```text
+docs/features/
+├── template.md              Template for new feature documents
+├── 01-configure/            Features concerned with defining inputs before a run
+├── 02-simulate/             Features concerned with the simulation computation
+├── 03-report/               Features concerned with presenting results to the user
+├── 04-exchange/             Features concerned with data import and export
+└── 90-testing/              Cross-cutting quality and verification concerns
+```
+
+The numbers establish a canonical reading and navigation order. `90-testing` is offset from the workflow sequence to signal that testing is a cross-cutting concern rather than a workflow phase.
+
+Within each subdirectory, files are named descriptively without further numbering. The README index in `docs/README.md` lists all feature documents grouped by subdirectory.
+
+## Rationale
+
+**Workflow phases over implementation layers.** The obvious alternative — grouping by code layer (UI vs simulation engine) — mirrors `src/ui.js` vs `src/simulation.js` but obscures design decisions that span both. Complexity limits, for example, have UI behaviour (error states, button disablement) and a simulation guard (JavaScript validation before the loop enters); assigning it to one layer hides half the decision. A workflow phase grouping allows a single document to cover both layers for a given feature, which is where the interesting decisions live.
+
+**Numbered directories over flat naming with prefixes.** A flat directory with filename prefixes (e.g. `simulate-complexity-limits.md`) achieves similar grouping in filesystem listings but makes the index harder to read and offers no explicit statement of intent about ordering. Subdirectories make the grouping a first-class structural fact and allow `docs/README.md` to present a clean two-level index.
+
+**`90-testing` offset.** Testing documents describe how correctness is verified across the application rather than any single workflow phase. Numbering them `05-` would imply they belong after exchange in a workflow sequence, which is misleading. The `90-` prefix signals separation from the workflow while keeping all feature documentation under a single directory.
+
+## Consequences
+
+### Positive
+
+- A reader unfamiliar with the application can navigate feature documentation in workflow order, building understanding incrementally
+- Cross-layer features (complexity limits, CSV import/export) have a natural home without splitting their documentation
+- The structure scales to full application coverage without reorganisation
+- The numbered prefix convention is self-documenting — the ordering rationale is visible in the filenames
+
+### Negative
+
+- Relative link paths within feature documents are one level deeper than before (`../../adr/` instead of `../adr/`), requiring updates to existing documents when they are moved
+- Subdirectory creation adds a small amount of friction when adding a new feature document for the first time in a category
+
+## Alternatives Considered
+
+### Alternative 1: Flat directory with filename prefixes
+
+Keep all feature documents in `docs/features/` with names like `simulate-monte-carlo-engine.md`. Achieves grouping in filesystem listings without subdirectory overhead, but the grouping is implicit and the index in README reads as a flat list rather than a structured hierarchy.
+
+### Alternative 2: Layer-based grouping (ui / simulation / testing)
+
+Mirrors the source structure (`src/ui.js`, `src/simulation.js`). Rejected because several features span both layers, and the documentation value is highest precisely at the boundary between them. A layer split would force artificial placement or document duplication.
+
+### Alternative 3: Single flat directory, no grouping
+
+The current state. Acceptable for three documents; does not scale to full application coverage and gives no navigational structure to a new reader.
+
+## References
+
+- [Feature Template](../features/template.md)
+- [ADR-0001: Repository Structure](0001-repository-structure.md)

--- a/docs/features/01-configure/simulation-parameters.md
+++ b/docs/features/01-configure/simulation-parameters.md
@@ -1,0 +1,120 @@
+# Feature: Simulation Parameters
+
+## Overview
+
+Six parameters in the Simulation Settings panel control how the Monte Carlo runs and what the results mean. They fall into three groups: capacity (total budget and weekly throughput), simulation fidelity (run count and programme quantity), and output calibration (confidence level and working hours per day). For the conceptual meaning of each, see [Foundation](../../foundation.md).
+
+## User Story
+
+As a capacity planner, I want to configure the simulation to reflect my team's actual capacity and the confidence threshold appropriate for my planning posture so that the results are directly comparable to my constraints.
+
+## Functionality
+
+### Parameters
+
+| Label | ID | Default | Min | Max | Description |
+|---|---|---|---|---|---|
+| Available Capacity (person-hours) | `capacity` | 800 | 1 | — | Total person-hour budget; basis for the over-capacity risk percentage |
+| Program Quantity | `programQuantity` | 3 | 1 | 100 | Number of parallel instances to simulate per run |
+| Simulation Runs | `simulations` | 1000 | 100 | 25,000 | Number of Monte Carlo iterations |
+| Confidence Level (%) | `confidence` | 80 | 50 | 99 | Percentile for highlighted results and the workload chart |
+| Hours per Work Day | `hoursPerDay` | 8 | 1 | 24 | Converts person-hours to calendar days for timeline output |
+| Max Weekly Capacity (hrs) | `weeklyCapacity` | 40 | 1 | — | Maximum hours available per week; scheduling throughput constraint |
+
+For the distinction between `capacity` (budget) and `weeklyCapacity` (throughput), and the role of `programQuantity`, see [Foundation](../../foundation.md#capacity-budget-and-throughput).
+
+### User Interface
+
+All six parameters must appear in a Simulation Settings panel above the task grid. `programQuantity` and `simulations` must each have a hidden inline error message that becomes visible when the value exceeds its hard limit; the Run button must be disabled until the value is corrected. The remaining four parameters must enforce basic bounds via the HTML `min` attribute.
+
+The simulation must run automatically a short delay after page load using the default values and the pre-populated tasks, so a result is visible without any user interaction.
+
+### Data Flow
+
+1. On Run, all six parameter values must be read and parsed
+2. `programQuantity`, `hoursPerDay`, and `weeklyCapacity` must be passed into the simulation engine on every iteration — they govern how individual runs execute
+3. `capacity`, `simulations`, and `confidence` must be applied in post-simulation calculations — they do not affect how runs execute, only how results are interpreted
+4. `capacity` must be compared against each run's total effort to compute the over-capacity percentage; `confidence` must select the percentile values highlighted in the results panel
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **User inputs**: Six numeric fields; values must be parsed to numbers before use
+
+#### Outbound Data Vectors
+
+- None — parameter values must be consumed within the simulation and must not be written to storage or included in any export
+
+#### Trust Boundaries
+
+- **Browser to application**: `simulations` and `programQuantity` must be validated in JavaScript before the simulation loop runs, in addition to HTML `max` attributes, since attributes can be bypassed via browser DevTools
+
+### Threat Model
+
+- **DoS via large parameter values**: Extreme `simulations` or `programQuantity` values could lock the browser tab → Mitigation: hard limits must be enforced in JavaScript; see [Simulation Complexity Limits](../02-simulate/simulation-complexity-limits.md)
+
+## Configuration
+
+Hard limits must be defined as named constants:
+
+| Constant | Value |
+|---|---|
+| `MAX_SIMULATIONS` | 25,000 |
+| `MAX_PROGRAM_QUANTITY` | 100 |
+
+## Usage Examples
+
+### Conservative planning for a small team
+
+```text
+Available Capacity:   400 person-hours
+Program Quantity:     1
+Simulation Runs:      1000
+Confidence Level:     90%
+Hours per Work Day:   6
+Max Weekly Capacity:  30 hrs/week
+```
+
+Single-instance programme, 90th-percentile confidence, part-time workstream.
+
+### Portfolio view across multiple instances
+
+```text
+Available Capacity:   2400 person-hours
+Program Quantity:     10
+Simulation Runs:      1000
+Confidence Level:     80%
+Hours per Work Day:   8
+Max Weekly Capacity:  40 hrs/week
+```
+
+Ten parallel instances sharing a standard 40-hour weekly capacity.
+
+## Validation & Error Handling
+
+- `simulations` above 25,000: input must be styled invalid, inline error must be shown, Run must be disabled
+- `programQuantity` above 100: same behaviour
+- Other parameters: HTML `min` attribute only; no additional JavaScript enforcement required
+- A non-numeric or empty field must not crash the application; results will be degenerate if fields are missing — all fields should contain valid numbers before running
+
+## Known Limitations
+
+- `capacity` and `weeklyCapacity` have no upper bound
+- There is no validation that `hoursPerDay` and `weeklyCapacity` are mutually consistent
+- Parameters are not persisted between page loads; defaults are restored on every reload
+
+## Future Enhancements
+
+- Persist parameter values in `localStorage` so they survive page reloads
+- Warn when the weekly capacity implies a lower daily rate than `hoursPerDay` suggests
+
+## Related Documentation
+
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Foundation — Programme Quantity](../../foundation.md#programme-quantity)
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Task Management](./task-management.md)
+- [Simulation Complexity Limits](../02-simulate/simulation-complexity-limits.md)

--- a/docs/features/01-configure/task-management.md
+++ b/docs/features/01-configure/task-management.md
@@ -1,0 +1,132 @@
+# Feature: Task Management
+
+## Overview
+
+Provides a dynamic task input grid where users define the work items to be simulated. Each task captures a name, an optional skip probability, PERT effort estimates for active work, and PERT estimates for any wait time that follows. The grid must support adding and removing tasks up to a maximum of 100, and must pre-populate with three representative example tasks on load.
+
+## User Story
+
+As a capacity planner, I want to define a list of tasks with three-point effort estimates so that the simulation can model the realistic range of outcomes for my programme.
+
+## Functionality
+
+### Core Features
+
+- Tasks must be addable and removable dynamically
+- The grid must pre-populate with three example tasks on load
+- Each task must have eight input fields and a Remove button
+- The Add Task button must be disabled and a limit message displayed once 100 tasks are present
+- Tasks must also be populatable programmatically to support CSV import — see [CSV Import/Export](../04-exchange/csv-import-export.md)
+
+### Task Schema
+
+Each task row must contain nine elements: eight inputs followed by one Remove button.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| Task Name | text | — | Free-text label; used in results display and CSV export |
+| Skip % | number | 0–95, step 5 | Probability the task is omitted in a given simulation run |
+| Work Opt (hrs) | number | min 0.1, step 0.1 | Optimistic work effort in person-hours |
+| Work Exp (hrs) | number | min 0.1, step 0.1 | Expected work effort in person-hours |
+| Work Pess (hrs) | number | min 0.1, step 0.1 | Pessimistic work effort in person-hours |
+| Wait Opt | number | min 0, step 0.1 | Optimistic wait time in days |
+| Wait Exp | number | min 0, step 0.1 | Expected wait time in days |
+| Wait Pess | number | min 0, step 0.1 | Pessimistic wait time in days |
+| Action | button | — | Removes the task row |
+
+Skip % must be capped at 95 — a task must not be unconditionally skippable through the UI. For the conceptual distinction between work effort and wait time, see [Foundation](../../foundation.md#tasks-work-and-wait).
+
+### Default Tasks
+
+The template must pre-populate with three tasks representing a typical parallel review process:
+
+| Task | Skip % | Work O/E/P (hrs) | Wait O/E/P (days) |
+|---|---|---|---|
+| Supplier Security Review | 0 | 8 / 32 / 96 | 0 / 2 / 5 |
+| Vulnerability Assessment | 0 | 24 / 64 / 120 | 1 / 3 / 7 |
+| Supplier Follow-up | 60 | 8 / 24 / 64 | 0 / 1 / 3 |
+
+The Supplier Follow-up task demonstrates skip probability: it is omitted in 60% of runs, reflecting that not every instance requires follow-up work.
+
+### User Interface
+
+Column headers (`Task Name`, `Skip %`, `Work Opt (hrs)`, etc.) must be rendered as a fixed header row above the task inputs. The Add Task button and a task limit message (`"Maximum of 100 tasks reached"`) must appear below the task list. The message must be hidden until the limit is reached; the button must be disabled at that point. Both must be re-evaluated after every add and remove operation.
+
+### Data Flow
+
+1. The user adds and edits tasks in the grid
+2. On Run, the UI reads all task rows and extracts the eight input values from each
+3. Rows where the task name or any work effort field is empty must be silently excluded — only complete rows must enter the simulation
+4. The resulting task array is passed into the simulation engine on each Monte Carlo iteration
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **Manual entry**: Task name is a free-text string entered by the user
+- **Programmatic population**: Task rows can be created with pre-filled values via the CSV import path
+
+#### Outbound Data Vectors
+
+- **DOM rendering**: Task names must be set via DOM property assignment — they must never be injected as HTML
+- **CSV export**: Task names must be passed through formula-injection sanitisation before export — see [CSV Import/Export](../04-exchange/csv-import-export.md)
+
+#### Trust Boundaries
+
+- **User input to DOM**: Task row construction must use DOM API calls throughout. Value assignment treats any string as text, not markup — `<script>` tags and event handler syntax must be inert
+
+### Threat Model
+
+- **XSS via task name**: A crafted task name containing HTML or event handler syntax enters the task grid → Mitigation: DOM API construction must be used; value assignment cannot inject elements or attributes regardless of string content
+- **XSS via CSV import**: Malicious field values in an uploaded file reach the task grid via the CSV parse path → Mitigation: the same DOM API construction must apply; no string sanitisation is required because the rendering mechanism is safe by construction
+
+### Security Controls
+
+- All task row construction must use DOM API calls (`createElement`, `setAttribute`, `element.value =`); `innerHTML` must not be used for user-supplied values — see [ADR-0014](../../adr/0014-dom-api-over-innerhtml.md)
+- The exact-structure invariant (8 inputs + 1 button per task div) must be verified by property-based security tests — see [UI Property-Based Security Tests](../90-testing/ui-property-based-security-tests.md)
+
+## Configuration
+
+| Constant | Value |
+|---|---|
+| `MAX_TASKS` | 100 |
+
+## Validation & Error Handling
+
+- Rows with an empty task name or any missing work effort field must be excluded from the simulation run without surfacing an error — the run must proceed on the remaining valid rows
+- Attempting to add a task when at the limit must have no effect
+- Work effort values are not required to form a valid range; an inverted range (pessimistic < optimistic) must be accepted and passed to the simulation engine, which handles it by returning the expected value when the range is zero or negative
+
+## Testing
+
+### Test Cases
+
+- A newly added task div has exactly 8 inputs followed by 1 button, for any combination of input values
+- No inline event handler attributes appear on any element in the task subtree for any task name, including strings containing `<`, `>`, `"`, `'`, and XSS payload patterns
+- Add Task button is disabled and limit message is visible when 100 tasks are present
+- Add Task button re-enables and limit message hides after a task is removed from a full list
+- Row with an empty task name: excluded from simulation, no error shown
+
+### Manual Testing Steps
+
+1. Load the application — confirm three pre-populated tasks are present
+2. Click Add Task — confirm a new empty row appears
+3. Add tasks until the 100th — confirm Add Task disables and limit message appears
+4. Remove one task — confirm Add Task re-enables and message hides
+5. Enter `<img src=x onerror=alert(1)>` as a task name and run — confirm no alert fires and the value is treated as plain text
+
+## Known Limitations
+
+- Tasks have no reorder capability; they execute in the order they appear in the grid
+- An inverted effort range (pessimistic < optimistic) is accepted without warning
+
+## Related Documentation
+
+- [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait)
+- [Foundation — Three-Point Estimation](../../foundation.md#three-point-estimation)
+- [Simulation Parameters](./simulation-parameters.md)
+- [CSV Import/Export](../04-exchange/csv-import-export.md)
+- [UI Property-Based Security Tests](../90-testing/ui-property-based-security-tests.md)
+- [ADR-0014: DOM API over innerHTML](../../adr/0014-dom-api-over-innerhtml.md)

--- a/docs/features/02-simulate/simulation-complexity-limits.md
+++ b/docs/features/02-simulate/simulation-complexity-limits.md
@@ -146,7 +146,3 @@ As a capacity planner, I want the tool to warn me before I kick off an unreasona
 
 - Move simulation loop to a Web Worker to keep the UI fully responsive during long runs
 - Adaptive budget estimate based on a short benchmark run on the user's device
-
-## Related Documentation
-
-- [Template](./template.md)

--- a/docs/features/90-testing/simulation-engine-property-based-tests.md
+++ b/docs/features/90-testing/simulation-engine-property-based-tests.md
@@ -158,5 +158,5 @@ See `test/simulation.test.js` for the full list. Key cases:
 
 ## Related Documentation
 
-- [ADR-0001](../adr/0001-repository-structure.md)
-- [Security Policy](../development/SECURITY.md)
+- [ADR-0001](../../adr/0001-repository-structure.md)
+- [Security Policy](../../development/SECURITY.md)

--- a/docs/features/90-testing/ui-property-based-security-tests.md
+++ b/docs/features/90-testing/ui-property-based-security-tests.md
@@ -110,5 +110,5 @@ Tests import `addTaskFromData` and `parseCSV` directly from `src/ui.js` as ES mo
 ## Related Documentation
 
 - [Feature: Simulation Engine Property-Based Tests](./simulation-engine-property-based-tests.md)
-- [ADR-0003: Property-Based Testing](../adr/0003-property-based-testing.md)
-- [Security Policy](../../SECURITY.md)
+- [ADR-0003: Property-Based Testing](../../adr/0003-property-based-testing.md)
+- [Security Policy](../../../SECURITY.md)

--- a/docs/features/template.md
+++ b/docs/features/template.md
@@ -1,5 +1,27 @@
 # Feature: [Feature Name]
 
+<!--
+FRAMING GUIDE
+
+These documents are specifications, not retrospective documentation. Write them
+as forward-looking declarations of what the feature must do, not descriptions of
+what the current implementation does.
+
+Language:
+- Use "must" for requirements: "Task names must be passed through sanitisation before export"
+- Use declarative present tense for facts about the model: "Each task row contains nine elements"
+- Avoid "is/are/does" when describing implementation behaviour — that framing documents the past
+- Do not reference function names, variable names, or line numbers unless this is a
+  technical feature (testing infrastructure, build tooling, security controls). For
+  user-facing features, describe behaviour and intent.
+
+Implementation Details section:
+- Include it only for technical features (e.g. property-based tests, build pipeline,
+  security tooling) where knowing the code structure is part of the specification
+- Omit it for user-facing features — the feature documents what the product must do,
+  not how it must be built
+-->
+
 ## Overview
 
 Brief description of what this feature does and why it exists.
@@ -12,17 +34,17 @@ As a [user type], I want [functionality] so that [benefit/goal].
 
 ### Core Features
 
-- Feature point 1
-- Feature point 2
-- Feature point 3
+- Feature requirement 1
+- Feature requirement 2
+- Feature requirement 3
 
 ### User Interface
 
-Describe the UI elements and user interactions for this feature.
+Describe the UI elements and interactions this feature requires.
 
 ### Data Flow
 
-Explain how data moves through the system for this feature.
+Explain how data must move through the system for this feature.
 
 ## Security Considerations
 
@@ -50,9 +72,8 @@ Explain how data moves through the system for this feature.
 
 ### Threat Model
 
-- **Threat 1**: [Description] → Mitigation: [How it's addressed]
-- **Threat 2**: [Description] → Mitigation: [How it's addressed]
-- **Threat 3**: [Description] → Mitigation: [How it's addressed]
+- **Threat 1**: [Description] → Mitigation: [How it must be addressed]
+- **Threat 2**: [Description] → Mitigation: [How it must be addressed]
 
 Common threats to consider:
 - **Data injection**: Malicious data in CSV files, user inputs
@@ -65,12 +86,15 @@ Common threats to consider:
 
 ### Security Controls
 
-- Input validation mechanisms
-- Output encoding/escaping
+- Input validation requirements
+- Output encoding/escaping requirements
 - Content Security Policy considerations
-- Safe defaults and fail-secure behaviors
-- Data sanitization for outbound flows
-- Secure data storage practices
+- Safe defaults and fail-secure behaviours
+- Data sanitisation for outbound flows
+
+<!--
+IMPLEMENTATION DETAILS — include this section only for technical features.
+Remove it for user-facing features.
 
 ## Implementation Details
 
@@ -81,17 +105,18 @@ Common threats to consider:
 
 ### Code Location
 
-- Primary implementation: `web/index.html` lines XXX-YYY
-- Related functions: `functionName()`, `anotherFunction()`
+- Primary implementation: `src/` — describe the relevant file and area
+- Related files: list other files involved
 
 ### Dependencies
 
 - External libraries used
 - Internal components depended upon
+-->
 
 ## Configuration
 
-Any configuration options or parameters that affect this feature.
+Any named constants or configuration values that govern this feature's behaviour.
 
 ## Usage Examples
 
@@ -104,14 +129,14 @@ Step-by-step example of basic usage
 ### Advanced Usage
 
 ```text
-Example of more complex usage scenarios
+Example of a more complex usage scenario
 ```
 
 ## Validation & Error Handling
 
 - Input validation rules
-- Error conditions and handling
-- User feedback mechanisms
+- Error conditions and how they must be handled
+- User feedback requirements
 - Security-related error handling
 - Outbound data validation
 
@@ -119,7 +144,7 @@ Example of more complex usage scenarios
 
 ### Test Cases
 
-- Test case 1: Expected behavior
+- Test case 1: Expected behaviour
 - Test case 2: Edge case handling
 - Test case 3: Error condition
 - **Security test cases**: Malicious input, boundary conditions, injection attempts
@@ -137,7 +162,7 @@ Example of more complex usage scenarios
 
 - Performance characteristics
 - Resource usage
-- Optimization notes
+- Optimisation requirements
 - DoS protection mechanisms
 
 ## Known Limitations

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -1,0 +1,70 @@
+# Foundation: How the Tool Works and Why
+
+This document explains the planning problem the tool addresses, the conceptual model it uses, and the reasoning behind the key design choices. Reading it first provides the needed context that will make the overall design make sense.
+
+## The Planning Problem
+
+Some programmes of work involve running the same process repeatedly, in parallel, across many instances — and the work is genuinely uncertain. A single instance might complete quickly and cleanly; another might turn out to be much more involved, require external responses, or trigger additional steps. The process is the same, but the outcomes vary widely.
+
+A team planning such a programme needs answers to two questions:
+
+- **How long will this take?** Given our team's capacity, when can we realistically expect to be done?
+- **Do we have enough capacity?** Is the total effort within our allocated budget, or are we likely to run over?
+
+Deterministic estimates — "each instance takes about X hours" — fail to capture the uncertainty. Average them and you get a median outcome that half the instances will exceed. Pad them and you lose the information about the range. What's actually needed is a model of the *distribution* of outcomes.
+
+## Monte Carlo Simulation
+
+Rather than producing a single estimate, the tool simulates the programme many times — typically 1,000 runs or more — with effort values drawn from statistical distributions on each run. Each run is one plausible version of how the programme might unfold. Across all runs, the tool builds up a distribution of outcomes: timelines, total effort, and week-by-week workload.
+
+This distribution answers both planning questions directly. The P50 outcome (the median) is the most likely result. The P80 or P90 outcome is what a cautious planner should commit to. The over-capacity percentage tells you how often the total effort exceeds your budget across all simulations — a concrete risk figure rather than a gut feel.
+
+## Tasks: Work and Wait
+
+Each step in the process is modelled as a **task** with two distinct time components.
+
+**Work effort** is the time your team actively spends on the task — hours of analysis, review, writing, or decision-making. This is the component that consumes your team's capacity.
+
+**Wait time** is calendar time that passes while something external happens: a supplier responds to a questionnaire, a stakeholder reviews a document, a meeting slot becomes available. Wait time adds to the calendar duration of the programme but does not consume your team's capacity. The team is free to work on other instances during a wait.
+
+Separating these matters because the two components affect planning in different ways. A task might require four hours of work but then sit for two weeks waiting for an external response. Treating those two weeks as "effort" would massively overstate the capacity cost; treating them as zero would understate the calendar timeline. Modelling them separately gives an accurate picture of both.
+
+## Three-Point Estimation
+
+For both work effort and wait time, you provide three estimates: **optimistic**, **expected**, and **pessimistic**. The tool fits a PERT distribution to these three points — a Beta distribution that clusters outcomes around the expected value but with a tail toward the pessimistic end, reflecting the asymmetric nature of real-world delays and overruns.
+
+Three-point estimation is a practical way to capture expert knowledge under uncertainty. It asks a question you can actually answer ("what's the best case, most likely case, and worst case?") rather than asking for a full probability distribution. The range between your optimistic and pessimistic estimates directly represents how much you know about a given task — a narrow range reflects confidence; a wide range reflects genuine uncertainty.
+
+## Optional Tasks
+
+Not every task happens in every instance. Some steps are only needed in certain circumstances — a follow-up investigation that only happens when initial findings are concerning, or an escalation that only occurs when a risk exceeds a threshold. Each task carries a **skip probability**: the percentage of simulation runs in which that task is omitted entirely. A task with a 60% skip probability is absent from 60% of runs, reflecting the real-world frequency with which that step is needed.
+
+## Programme Quantity
+
+The same process often runs in parallel across many instances simultaneously — multiple suppliers being reviewed, multiple sites being assessed, multiple components being evaluated. The **programme quantity** parameter specifies how many parallel instances are simulated in each run.
+
+All instances share the same weekly capacity constraint. If the team has 40 hours per week to dedicate to the programme and there are ten parallel instances, the scheduler has to fit all ten within that 40-hour window — it cannot pretend each instance gets 40 hours independently. This is what makes parallel programmes genuinely harder to plan than sequential ones: contention for shared capacity stretches the calendar even when the total effort looks manageable.
+
+## Capacity: Budget and Throughput
+
+The tool models capacity in two distinct ways because two distinct constraints apply to any programme.
+
+**Available capacity** is the total person-hour budget allocated to the programme. It is a cumulative figure — the total hours the team is permitted to spend across the entire exercise. Exceeding it is a resource and cost problem.
+
+**Weekly capacity** is the throughput rate — how many hours per week this team can dedicate to this programme. It is a scheduling constraint. Even if the total budget is ample, a low weekly capacity stretches the calendar: work queues up and cannot be completed any faster than the weekly rate allows.
+
+These constraints bind independently. A team might have a generous total budget but a limited weekly allocation because the people involved have other commitments. In that case the programme will take longer on the calendar even though total effort is within budget. Both constraints need to be planned against.
+
+## Reading the Results
+
+The simulation produces a distribution of outcomes rather than a single number. The key outputs are:
+
+**Effort percentiles** (P10, P50, P90, and the selected confidence value) describe the distribution of total person-hours across all simulation runs. P50 is the median; P90 means 90% of runs completed within that effort figure.
+
+**Timeline percentiles** describe the same distribution for total calendar duration in business days.
+
+**Over-capacity risk** is the percentage of simulation runs in which total effort exceeded the available capacity budget. A figure above 20% is a strong signal to revisit scope or increase capacity; below 5% represents a comfortable buffer.
+
+**The workload chart** shows the average weekly hours required across the subset of simulations that fell near the selected confidence percentile. It reveals when during the programme the team will be most stretched, and which weeks are likely to exceed weekly capacity.
+
+**The confidence level** is a planning choice, not a statistical fact. Choosing 80% means "I want a plan that works in 80% of plausible outcomes." A risk-tolerant team might use 70%; a team that cannot afford overruns might use 90%. The same simulation data supports any confidence level — adjust it to match your planning posture.


### PR DESCRIPTION
## Summary

- Adds ADR-0015 establishing numbered workflow-phase subdirectories as the organising principle for `docs/features/`
- Reorganises existing feature docs into `02-simulate/` and `90-testing/` subdirectories accordingly
- Adds `foundation.md` as the recommended entry point for the project — covers the planning problem, Monte Carlo approach, and conceptual model
- Adds initial `01-configure/` feature documentation and updates the feature template

## Note

ADR-0015 is in the existing numbered ADR format. It will be superseded by the declarative ADR restructuring on `docs/declarative-adrs`, which converts all numbered ADRs to topic-based directories — that branch should be rebased onto this one once merged.

## Test plan

- [ ] All internal links in new and moved files resolve correctly
- [ ] `docs/README.md` entry point link to `foundation.md` works
- [ ] Feature docs appear under correct phase subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)