### PR TITLE
docs: split dependency review log into per-date files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@
 ### For maintainers
 - **[Architecture Decision Records](adr/)** — current architectural decisions by topic
 - **[Feature Documentation](features/)** — feature specifications by workflow phase
-- **[Dependency Review Log](development/dependency-review-log.md)** — periodic dependency health assessments
+- **[Dependency Reviews](development/dependency-reviews/)** — periodic dependency health assessments
 
 ## Documentation Structure
 
@@ -39,7 +39,8 @@ docs/
 └── development/               Contributor and maintenance docs
     ├── CONTRIBUTING.md
     ├── SECURITY.md
-    └── dependency-review-log.md
+    └── dependency-reviews/    Per-date dependency health assessments
+        └── YYYY-MM-DD.md
 ```
 
 ## Documentation Standards
@@ -52,5 +53,5 @@ docs/
 ## Maintenance
 
 - ADRs describe current architectural state; update them in place when the architecture changes
-- Dependency health assessments are recorded in `development/dependency-review-log.md`
+- Dependency health assessments are recorded in `development/dependency-reviews/`
 - Feature documentation should be updated when features change

--- a/docs/adr/dependencies/dependency-policy.md
+++ b/docs/adr/dependencies/dependency-policy.md
@@ -33,9 +33,9 @@ Each dependency ADR must document:
 
 ### Periodic review
 
-Dependencies must be reviewed periodically. The outcome — including date, dependencies assessed, and actions taken or deferred — is recorded in `docs/development/dependency-review-log.md`. An entry is required even when no action is taken.
+Dependencies must be reviewed periodically. Each review is recorded as a separate file named `YYYY-MM-DD.md` in `docs/development/dependency-reviews/`, using the template at `docs/development/dependency-reviews/template.md`. An entry is required even when no action is taken.
 
-A dependency failing one criterion warrants monitoring and a note in the review log. Failure of two or more criteria warrants a replacement ADR.
+A dependency failing one criterion warrants monitoring and a note in the review file. Failure of two or more criteria warrants a replacement ADR.
 
 ### Grandfathered dependencies
 
@@ -71,5 +71,10 @@ The dependencies present when this policy was adopted — `eslint`, `fast-check`
 
 ## References
 
-- [dependency-review-log.md](../development/dependency-review-log.md)
+- [dependency-reviews/](../development/dependency-reviews/)
 - [../security/openssf-scorecard.md](../security/openssf-scorecard.md)
+
+## History
+
+- **Reviews recorded in a single log file** — all review entries appended to `docs/development/dependency-review-log.md`.
+- **Reviews split into per-date files** — log replaced with `docs/development/dependency-reviews/YYYY-MM-DD.md` files to make it easier to see at a glance when reviews have been done.

--- a/docs/development/dependency-reviews/2026-05-10.md
+++ b/docs/development/dependency-reviews/2026-05-10.md
@@ -1,36 +1,7 @@
-# Dependency Review Log
-
-Records the outcome of each periodic health review of direct dependencies, as required by the [dependency policy](../adr/dependencies/dependency-policy.md).
-
-An entry is required after every review, including reviews where no action is taken.
-
----
-
-## Review template
-
-```
-## Review YYYY-MM-DD
-
-**Reviewer**: [Name]
-**Scope**: [All dependencies | specific packages] — [reason, e.g. scheduled review, new dependency added, CVE alert]
-
-| Dependency | Version | Maintained | Security | Responsiveness | Downloads | Continuity | Not deprecated | Outcome |
-|---|---|---|---|---|---|---|---|---|
-| `package-name` | x.y.z | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | No action / Monitor / ADR-XXXX raised |
-
-**Notes**: [Any findings, mitigations accepted, or context for deferred actions]
-
-**Next review due**: YYYY-MM-DD
-```
-
-Criteria reference: see [dependency policy — Health assessment criteria](../adr/dependencies/dependency-policy.md#health-assessment-criteria).
-
----
-
-## Review 2026-05-10
+# Dependency Review 2026-05-10
 
 **Reviewer**: Gareth Marshall
-**Scope**: All dependencies — first periodic review; grandfathered packages (`eslint`, `fast-check`, `html-validate`, `vitest`) and grandfathered CDN dependency (`Chart.js`) assessed for the first time per the dependency policy; `happy-dom` reviewed in [dependencies/happy-dom.md](../adr/dependencies/happy-dom.md) (2026-05-10) and included here for completeness. `PapaParse` reviewed in [dependencies/papaparse.md](../adr/dependencies/papaparse.md) (2026-05-10) and omitted here as its health assessment was recorded at adoption. Chart.js was inadvertently omitted from the initial entry and added by supplement.
+**Scope**: All dependencies — first periodic review; grandfathered packages (`eslint`, `fast-check`, `html-validate`, `vitest`) and grandfathered CDN dependency (`Chart.js`) assessed for the first time per the dependency policy; `happy-dom` reviewed in [dependencies/happy-dom.md](../../adr/dependencies/happy-dom.md) (2026-05-10) and included here for completeness. `PapaParse` reviewed in [dependencies/papaparse.md](../../adr/dependencies/papaparse.md) (2026-05-10) and omitted here as its health assessment was recorded at adoption. Chart.js was inadvertently omitted from the initial entry and added by supplement.
 
 | Dependency | Version | Maintained | Security | Responsiveness | Downloads | Continuity | Not deprecated | Outcome |
 |---|---|---|---|---|---|---|---|---|
@@ -48,7 +19,7 @@ Criteria reference: see [dependency policy — Health assessment criteria](../ad
 - **fast-check** (15M downloads/week): v4.7.0 released 2026-04-17; active release cadence with minor versions shipping roughly monthly. Single maintainer (Nicolas Dubien, `ndubien`). No organisational backing; flagged for monitoring. No CVEs, no deprecation.
 - **html-validate** (397K downloads/week): v10.15.0 released 2026-05-04; we are pinned to 10.13.1. Lower download volume is expected for a specialised HTML linting tool rather than a sign of community abandonment — the release cadence (multiple releases per month in 2026) is healthy. Hosted on GitLab. Single maintainer (`ext` / sidvind.com). Flagged for monitoring. No CVEs, no deprecation. Consider updating the pinned version to 10.15.0 in a maintenance pass.
 - **vitest** (59M downloads/week): v4.1.5 released 2026-04-21; v5.0.0-beta.2 published 2026-05-05, indicating an active major version cycle. Multiple named maintainers including Evan You (creator of Vite/Vue) and Anthony Fu. No concerns. Monitor v5 stable release for a future upgrade decision.
-- **happy-dom** (8.2M downloads/week): v20.9.0 released 2026-04-13. Versions 20.8.8 and 20.8.9 (March 2026) included security fixes for a cookie-forwarding vulnerability and an ESM export-name interpolation issue; our pinned version incorporates both patches. Single maintainer (David Ortner, `davidortner`). Flagged for monitoring. Detailed health assessment recorded in [dependencies/happy-dom.md](../adr/dependencies/happy-dom.md) at adoption.
+- **happy-dom** (8.2M downloads/week): v20.9.0 released 2026-04-13. Versions 20.8.8 and 20.8.9 (March 2026) included security fixes for a cookie-forwarding vulnerability and an ESM export-name interpolation issue; our pinned version incorporates both patches. Single maintainer (David Ortner, `davidortner`). Flagged for monitoring. Detailed health assessment recorded in [dependencies/happy-dom.md](../../adr/dependencies/happy-dom.md) at adoption.
 - **Chart.js** (CDN, ~11.1M npm downloads/week): grandfathered CDN dependency per the dependency policy. Actively maintained with five named maintainers (`nnnick`, `tannerlinsley`, `etimberg`, `simonbrunel`, `chartjs-ci`); no single-maintainer risk. No CVEs in the 4.x line — Snyk confirms 4.4.1 has no known vulnerabilities; the only historical CVE (CVE-2020-7746, prototype pollution, 2020) affects the 2.x line only and was fixed in 2.9.4. Not deprecated; 4.x is the current stable line. The pinned version (4.4.1, January 2024) was 10 releases behind the latest stable at review time (4.5.1 on npm; 4.5.0 on cdnjs). None of the intervening releases contained security fixes. CDN pin updated to 4.5.0 with the corresponding SRI hash as a routine maintenance action. Note: Dependabot does not cover CDN dependencies — version currency must be verified manually at each review.
 
 **Single-maintainer monitoring**: three packages (`fast-check`, `html-validate`, `happy-dom`) are maintained by a single individual with no organisational backing. Each fails only the Continuity criterion; none triggers the two-criterion threshold requiring a replacement ADR. These packages should be observed at each subsequent review for signs of disengagement (no releases for 12+ months, unacknowledged issues, npm deprecation notice).

--- a/docs/development/dependency-reviews/template.md
+++ b/docs/development/dependency-reviews/template.md
@@ -8,7 +8,7 @@ Save this file as `YYYY-MM-DD.md` in `docs/development/dependency-reviews/`.
 
 ---
 
-## Review YYYY-MM-DD
+## Dependency Review YYYY-MM-DD
 
 **Reviewer**: [Name]
 **Scope**: [All dependencies | specific packages] — [reason, e.g. scheduled review, new dependency added, CVE alert]

--- a/docs/development/dependency-reviews/template.md
+++ b/docs/development/dependency-reviews/template.md
@@ -1,0 +1,26 @@
+# Dependency Review Template
+
+Records the outcome of a periodic health review of direct dependencies, as required by the [dependency policy](../../adr/dependencies/dependency-policy.md).
+
+An entry is required after every review, including reviews where no action is taken.
+
+Save this file as `YYYY-MM-DD.md` in `docs/development/dependency-reviews/`.
+
+---
+
+## Review YYYY-MM-DD
+
+**Reviewer**: [Name]
+**Scope**: [All dependencies | specific packages] — [reason, e.g. scheduled review, new dependency added, CVE alert]
+
+| Dependency | Version | Maintained | Security | Responsiveness | Downloads | Continuity | Not deprecated | Outcome |
+|---|---|---|---|---|---|---|---|---|
+| `package-name` | x.y.z | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | No action / Monitor / ADR-XXXX raised |
+
+**Notes**: [Any findings, mitigations accepted, or context for deferred actions]
+
+**Next review due**: YYYY-MM-DD
+
+---
+
+Criteria reference: see [dependency policy — Health assessment criteria](../../adr/dependencies/dependency-policy.md#health-assessment-criteria).


### PR DESCRIPTION
## Summary

- Replaces `docs/development/dependency-review-log.md` with individual `YYYY-MM-DD.md` files under `docs/development/dependency-reviews/`
- Adds `docs/development/dependency-reviews/template.md` for future reviews
- Updates the dependency policy ADR: Periodic review section, References link, and a new History entry recording the structural change
- Updates `docs/README.md` nav link, directory tree, and Maintenance note

Depends on #docs/declarative-adrs (new ADR structure that introduced `docs/adr/dependencies/dependency-policy.md`).

## Test plan

- [ ] Verify all internal links in the new files resolve correctly
- [ ] Confirm `2026-05-10.md` contains the full content of the original review entry
- [ ] Check `docs/README.md` directory tree matches the actual file layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)