### PR TITLE
docs: consolidate contributor and maintainer nav sections in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,6 @@
 - **[Foundation](foundation.md)** — start here to understand the design intent
 - **[Contributing Guide](development/CONTRIBUTING.md)** — how to contribute
 - **[Branch Policy](adr/development/branch-policy.md)** — branch naming and scoping
-
-### For maintainers
 - **[Architecture Decision Records](adr/)** — current architectural decisions by topic
 - **[Feature Documentation](features/)** — feature specifications by workflow phase
 - **[Dependency Reviews](development/dependency-reviews/)** — periodic dependency health assessments


### PR DESCRIPTION
## Summary

- Merges the "For contributors" and "For maintainers" nav sections into a single "For contributors" section — the distinction between the two audiences is artificial in a project of this size

Depends on #88 (introduces the nav structure this builds on).

## Test plan

- [ ] Verify all links in the nav section still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)