### PR TITLE
docs: add feature documents for 03-report section

### DIFF
--- a/docs/features/03-report/capacity-assessment.md
+++ b/docs/features/03-report/capacity-assessment.md
@@ -1,0 +1,63 @@
+# Feature: Capacity Assessment
+
+## Overview
+
+The Capacity Assessment is a plain-language message that appears immediately below the Effort Analysis grid. It translates the over-capacity risk percentage into a risk level and provides guidance appropriate to that level — making it easier to communicate the headline finding without requiring the reader to interpret the raw percentage themselves.
+
+## User Story
+
+As a capacity planner, I want the simulation to tell me in plain language whether my capacity budget looks adequate so that I can quickly judge whether action is needed without doing the interpretation myself.
+
+## Functionality
+
+### Risk Classification
+
+The over-capacity risk percentage (the proportion of simulation runs in which total effort exceeded the available capacity budget) is mapped to one of three risk levels:
+
+| Risk level | Threshold | Indicator |
+|---|---|---|
+| Low | ≤ 5% | ✅ Good Capacity |
+| Moderate | 6–20% | ⚠️ Moderate Risk |
+| High | > 20% | ⚠️ Capacity Risk |
+
+### Message Content
+
+Each risk level produces a distinct message:
+
+**Low (≤ 5%)**
+> Good Capacity: Only *X*% chance of exceeding available hours. Reasonable buffer for unexpected work.
+
+**Moderate (6–20%)**
+> Moderate Risk: *X*% chance of exceeding available hours. Monitor closely and have contingency plans.
+
+**High (> 20%)**
+> Capacity Risk: *X*% chance of exceeding available hours. Consider reducing scope or increasing capacity.
+
+The message is visually styled to match the risk level — the high and moderate messages use a warning style; the low message uses a positive style.
+
+### Risk Level in the Executive Summary
+
+The same risk classification appears again in the Executive Summary's Resource Requirements card, under the label "Capacity Risk Level". There it is colour-coded rather than carrying a full message, providing a compact status indicator for stakeholder-facing communication.
+
+### Relationship to the Over Capacity Risk Metric
+
+The Capacity Assessment does not introduce new information — it is a presentation layer over the Over Capacity Risk percentage shown in the [Effort Analysis](./effort-analysis.md) grid. The percentage drives both the metric value and the assessment message from the same source.
+
+## Known Limitations
+
+- The risk thresholds (5% and 20%) are fixed. There is no way to adjust them to match a particular organisation's risk tolerance.
+- The guidance text is generic. It does not suggest which specific tasks to descope or how much additional capacity would be needed to reach a lower risk level.
+- A programme at exactly 20.0% receives a Moderate classification rather than High; the boundary behaviour is consistent but not surfaced to the user.
+
+## Future Enhancements
+
+- Allow the risk thresholds to be configured to match organisational standards.
+- Add specific guidance based on the gap between confidence-level effort and available capacity (e.g. "You are *X* hours over budget at your chosen confidence level").
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Report Structure](./report-structure.md)
+- [Effort Analysis](./effort-analysis.md) — the over-capacity risk percentage that this message is based on
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `capacity` parameter determines what counts as "over capacity"

--- a/docs/features/03-report/distribution-charts.md
+++ b/docs/features/03-report/distribution-charts.md
@@ -1,0 +1,52 @@
+# Feature: Distribution Charts
+
+## Overview
+
+Two histogram charts appear between the Timeline Analysis grid and the Weekly Workload chart. They show the full shape of the effort and timeline distributions across all simulation runs, complementing the percentile metrics by revealing how spread out outcomes are and whether the distribution has a long tail.
+
+## User Story
+
+As a capacity planner, I want to see the full distribution of simulation outcomes as a chart so that I can judge whether results are tightly clustered or spread across a wide range, and whether there are outlying scenarios I need to plan for.
+
+## Functionality
+
+### Effort Distribution Chart
+
+The effort distribution chart shows how frequently each effort range occurred across all simulation runs. The horizontal axis represents total effort in person-hours; the vertical axis represents how many runs produced an outcome in each range.
+
+The chart answers questions such as:
+- Is there a clear most-likely outcome, or is effort spread across a broad range?
+- Is there a tail of high-effort runs that the P90 figure is capturing?
+- How far apart are the typical and worst-case outcomes?
+
+### Timeline Distribution Chart
+
+The timeline distribution chart has the same structure, with total calendar duration in business days on the horizontal axis. It reveals the shape of the timeline distribution independently from effort — a programme with moderate effort variance can still show a wide timeline distribution if weekly capacity is constrained.
+
+### Relationship to the Metrics Grids
+
+The percentile metrics in the [Effort Analysis](./effort-analysis.md) and [Timeline Analysis](./timeline-analysis.md) sections read specific points off these distributions. The charts make the underlying distributions visible, so the user can see what lies between those points — for example, whether the gap between P50 and P90 represents a gradual slope or a sharp jump.
+
+### Bin Resolution
+
+Each chart divides the full range of outcomes into 50 equal-width bins. With a typical run count of 1,000 or more, this provides enough resolution to reveal the distribution shape without excessive noise.
+
+## Known Limitations
+
+- Bin width is fixed at 1/50th of the outcome range. A very narrow distribution with a few extreme outliers can result in most bars clustering at one end with a long sparse tail.
+- The charts do not mark the percentile values or the confidence-level value on the chart itself; those figures appear only in the metrics grids above.
+- The available capacity budget is not shown as a reference line on the effort chart; that context is provided by the Effort Analysis grid and the [Capacity Assessment](./capacity-assessment.md) message instead.
+
+## Future Enhancements
+
+- Overlay markers for P50, the confidence-level percentile, and P90 on each chart to connect the visual distribution to the headline metrics.
+- Add a reference line at the available capacity value on the effort chart.
+- Allow the bin count to be adjusted for users who want more or less granularity.
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Report Structure](./report-structure.md)
+- [Effort Analysis](./effort-analysis.md)
+- [Timeline Analysis](./timeline-analysis.md)
+- [Workload Chart](./workload-chart.md)

--- a/docs/features/03-report/effort-analysis.md
+++ b/docs/features/03-report/effort-analysis.md
@@ -1,0 +1,77 @@
+# Feature: Effort Analysis
+
+## Overview
+
+The Effort Analysis section presents a grid of six metrics derived from the simulation's effort distribution. It answers the two core capacity planning questions: how much work does this programme require, and does that fit within the available budget?
+
+## User Story
+
+As a capacity planner, I want to see the spread of effort outcomes across all simulation runs so that I can understand the realistic range of person-hours required and know whether my capacity budget is adequate.
+
+## Functionality
+
+### Metrics Grid
+
+Six metrics are displayed in a grid. All values are in person-hours.
+
+| Metric | What it shows |
+|---|---|
+| Mean Effort | The average total effort across all simulation runs. Useful as a rough centre-of-mass but sensitive to extreme outcomes. |
+| Median (P50) | The midpoint of the effort distribution — half of all runs fell below this value. The most neutral planning figure. |
+| *N*% Confidence | The effort value at the user's chosen confidence level. This is the figure a planner should commit to if they want the programme to stay within budget in *N*% of plausible outcomes. The label updates to reflect the current confidence setting. |
+| P90 (Worst Case) | The effort value that 90% of runs fell below. A conservative upper bound for contingency planning. |
+| Available Capacity | The person-hour budget entered in Simulation Settings. Shown here to give the over-capacity figure immediate context without requiring the user to look elsewhere. |
+| Over Capacity Risk | The percentage of simulation runs in which total effort exceeded the available capacity budget. This is the headline risk figure for the programme. |
+
+### Capacity Risk Interpretation
+
+The Over Capacity Risk percentage is the primary signal for whether the programme is resourced adequately:
+
+| Risk percentage | Interpretation |
+|---|---|
+| ≤ 5% | Comfortable buffer — the capacity budget covers the programme in the large majority of outcomes |
+| 6–20% | Moderate risk — the budget may be insufficient; contingency plans are advisable |
+| > 20% | High risk — the budget is likely to be exceeded; scope reduction or capacity increase should be considered |
+
+These same thresholds drive the [Capacity Assessment](./capacity-assessment.md) message that appears immediately below the grid.
+
+### Executive Summary
+
+The three effort values most useful for stakeholder communication are also presented in the Executive Summary's Planning Scenarios card, paired with their corresponding timeline values:
+
+| Scenario | Effort value used |
+|---|---|
+| Most Likely Outcome | P50 |
+| Conservative Planning | *N*% Confidence |
+| Contingency Planning | P90 |
+
+See [Timeline Analysis](./timeline-analysis.md) for the timeline values that appear alongside these.
+
+### Data Flow
+
+Effort values are derived from the sorted array of total effort outputs across all simulation runs. Percentiles are read by position in that sorted array. The over-capacity risk is computed as the proportion of runs whose total effort exceeded the available capacity value.
+
+## Security Considerations
+
+All displayed values are numbers computed from simulation output. No user-supplied strings (such as task names) appear in this section. The available capacity value is echoed from a numeric form field.
+
+## Known Limitations
+
+- P10 is not displayed. It is available from the simulation data but the current design shows only P50, the confidence percentile, and P90.
+- Mean and median can diverge significantly on skewed distributions; the grid shows both but does not annotate the difference.
+- The confidence-percentile label reads "*N*% Confidence" regardless of what *N* is — there is no guidance indicating whether a given confidence level is appropriate for the user's planning posture.
+
+## Future Enhancements
+
+- Add P10 to the grid to show the optimistic tail alongside the pessimistic one.
+- Allow the confidence level to be adjusted after the simulation has run, since all percentile data is already available without re-running.
+- Annotate the mean/median comparison when they differ by more than a threshold, flagging a skewed distribution.
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Report Structure](./report-structure.md)
+- [Capacity Assessment](./capacity-assessment.md)
+- [Timeline Analysis](./timeline-analysis.md)
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `confidence` and `capacity` parameters directly shape what this section displays

--- a/docs/features/03-report/executive-summary.md
+++ b/docs/features/03-report/executive-summary.md
@@ -1,0 +1,84 @@
+# Feature: Executive Summary
+
+## Overview
+
+The Executive Summary appears at the bottom of the report. It reframes the simulation output as three named planning scenarios and two resource figures, making the results easier to communicate to stakeholders who may not be familiar with percentile statistics. It draws on data already present in the report sections above; it does not introduce new computations.
+
+## User Story
+
+As a capacity planner, I want the key findings presented as named scenarios rather than raw percentiles so that I can share the results with stakeholders who are not familiar with Monte Carlo output.
+
+## Functionality
+
+### Structure
+
+The Executive Summary contains two cards displayed side by side.
+
+```
+┌─────────────────────────────┬─────────────────────────────┐
+│  Planning Scenarios         │  Resource Requirements      │
+│                             │                             │
+│  Most Likely Outcome        │  Expected Weekly Capacity   │
+│  Conservative Planning      │  Peak Weekly Demand         │
+│  Contingency Planning       │  Capacity Risk Level        │
+└─────────────────────────────┴─────────────────────────────┘
+```
+
+### Planning Scenarios Card
+
+Three scenarios are shown, each pairing an effort value (person-hours) with a timeline value (business days):
+
+| Scenario name | Effort value | Timeline value |
+|---|---|---|
+| Most Likely Outcome | P50 effort | P50 timeline |
+| Conservative Planning | *N*% confidence effort | *N*% confidence timeline |
+| Contingency Planning | P90 effort | P90 timeline |
+
+The scenario names are fixed strings. They are intended to map to recognisable planning postures: P50 for the most neutral estimate, the confidence-level percentile for the committed plan, and P90 for a reserve or contingency allowance.
+
+The confidence-level values in the Conservative Planning row reflect whatever confidence level is set in Simulation Settings. Choosing a higher confidence level (e.g. 90%) produces a more cautious conservative plan than a lower one (e.g. 70%).
+
+### Resource Requirements Card
+
+Three figures are shown:
+
+| Label | Value | Source |
+|---|---|---|
+| Expected Weekly Capacity | Average hours per week across the programme | Derived from the workload chart data |
+| Peak Weekly Demand | Highest hours required in any single week | Derived from the workload chart data |
+| Capacity Risk Level | High, Moderate, or Low | Same classification as the [Capacity Assessment](./capacity-assessment.md) message |
+
+The Capacity Risk Level is colour-coded to match its severity, giving a compact visual status for use in stakeholder documents or screenshots.
+
+### Relationship to Other Report Sections
+
+The Executive Summary does not introduce new values. Every figure it presents is derived from data already shown in the report:
+
+- The three scenario effort values come from the [Effort Analysis](./effort-analysis.md) grid
+- The three scenario timeline values come from the [Timeline Analysis](./timeline-analysis.md) grid
+- The resource figures come from the [Workload Chart](./workload-chart.md)
+- The risk level comes from the [Capacity Assessment](./capacity-assessment.md)
+
+Its purpose is synthesis and presentation, not additional analysis.
+
+## Known Limitations
+
+- The scenario names are fixed. "Conservative Planning" is used for the confidence-level percentile regardless of what that percentile is; at an unusually low confidence level (e.g. 60%) the label is misleading.
+- The two-card layout assumes the user always wants both planning scenarios and resource requirements. There is no way to show one without the other.
+- The resource figures (expected weekly capacity, peak demand) are derived from the confidence-band workload data; they reflect the chosen planning scenario, not the average across all runs.
+
+## Future Enhancements
+
+- Allow the scenario names to be customised to match an organisation's terminology.
+- Add a copy-to-clipboard or export option for the executive summary card content.
+- Reflect the chosen confidence level in the Conservative Planning label (e.g. "80% Confidence Plan").
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Report Structure](./report-structure.md)
+- [Effort Analysis](./effort-analysis.md)
+- [Timeline Analysis](./timeline-analysis.md)
+- [Capacity Assessment](./capacity-assessment.md)
+- [Workload Chart](./workload-chart.md)
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `confidence` parameter determines which percentile the Conservative Planning row uses

--- a/docs/features/03-report/report-structure.md
+++ b/docs/features/03-report/report-structure.md
@@ -1,0 +1,97 @@
+# Feature: Report Structure
+
+## Overview
+
+After a simulation run completes, a results report appears below the task grid. The report is divided into named sections in a fixed order, presenting the simulation output from the most specific (raw percentile metrics) to the most synthesised (executive summary planning scenarios). Every run replaces the entire report with freshly computed output.
+
+## User Story
+
+As a capacity planner, I want the simulation output to appear in a consistently structured report so that I can navigate to the same sections in the same order regardless of which parameters I changed between runs.
+
+## Functionality
+
+### Report Visibility
+
+The report area is not visible when the page loads. It becomes visible the first time a simulation run completes. Subsequent runs replace the report content in full — there is no partial update and no values from a prior run persist into the current display.
+
+Because the simulation runs automatically on page load using the default parameters and pre-populated tasks, a result is present without any user interaction.
+
+### Section Structure
+
+The report contains seven sections in a fixed top-to-bottom order:
+
+```
+┌─────────────────────────────────────────┐
+│  Simulation Results                     │
+│                                         │
+│  Effort Analysis (person-hours)         │
+│  ┌───────────────────────────────────┐  │
+│  │  metrics grid (6 values)          │  │
+│  └───────────────────────────────────┘  │
+│  [capacity assessment message]          │
+│                                         │
+│  Timeline Analysis (days)               │
+│  ┌───────────────────────────────────┐  │
+│  │  metrics grid (4 values)          │  │
+│  └───────────────────────────────────┘  │
+│                                         │
+│  [effort distribution chart]            │
+│  [timeline distribution chart]          │
+│                                         │
+│  Weekly Workload                        │
+│  [workload bar chart]                   │
+│                                         │
+│  ┌─────────────────┬─────────────────┐  │
+│  │  Planning       │  Resource       │  │
+│  │  Scenarios      │  Requirements   │  │
+│  └─────────────────┴─────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+| Section | Purpose |
+|---|---|
+| Effort Analysis | Person-hour percentiles and over-capacity risk — see [Effort Analysis](./effort-analysis.md) |
+| Capacity Assessment | Plain-language risk message below the effort grid — see [Capacity Assessment](./capacity-assessment.md) |
+| Timeline Analysis | Calendar-day percentiles — see [Timeline Analysis](./timeline-analysis.md) |
+| Distribution charts | Histograms of effort and timeline outcomes — see [Distribution Charts](./distribution-charts.md) |
+| Weekly Workload chart | Week-by-week capacity demand — see [Workload Chart](./workload-chart.md) |
+| Executive Summary | Named planning scenarios and resource figures — see [Executive Summary](./executive-summary.md) |
+
+### Section Headings
+
+Each section carries a fixed heading. The workload chart heading incorporates the active confidence level and the number of simulations that contributed to it; all other headings are static.
+
+### Replacement Behaviour
+
+Every run replaces the entire report in a single operation. The UI must not leave partially-updated content visible to the user if a run completes while a previous run's output is still displayed.
+
+## Security Considerations
+
+### Attack Surface
+
+The report area renders only values derived from simulation computation. No user-supplied strings (such as task names) appear anywhere in the report structure.
+
+### Threat Model
+
+- **Stale content across runs**: Updating only part of the report on a new run could leave prior values visible alongside new ones. Mitigation: the full report is replaced atomically on each run.
+
+## Known Limitations
+
+- The section order is fixed; there is no user control over which sections appear or in what order.
+- The report has no print-specific layout; printed output reflects the screen presentation.
+
+## Future Enhancements
+
+- A print or export view that renders only the executive summary as a standalone document.
+- Collapsible sections for users who want to focus on specific parts of the report.
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Effort Analysis](./effort-analysis.md)
+- [Timeline Analysis](./timeline-analysis.md)
+- [Capacity Assessment](./capacity-assessment.md)
+- [Distribution Charts](./distribution-charts.md)
+- [Workload Chart](./workload-chart.md)
+- [Executive Summary](./executive-summary.md)
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the confidence level setting shapes the highlighted metrics and chart headings throughout the report

--- a/docs/features/03-report/timeline-analysis.md
+++ b/docs/features/03-report/timeline-analysis.md
@@ -1,0 +1,72 @@
+# Feature: Timeline Analysis
+
+## Overview
+
+The Timeline Analysis section presents a grid of four metrics derived from the simulation's calendar-duration distribution. It answers the scheduling question: when will this programme realistically complete?
+
+## User Story
+
+As a capacity planner, I want to see the spread of calendar durations across all simulation runs so that I can commit to a realistic completion date with confidence.
+
+## Functionality
+
+### Metrics Grid
+
+Four metrics are displayed in a grid. All values are in business days.
+
+| Metric | What it shows |
+|---|---|
+| Mean Timeline | The average calendar duration across all simulation runs. |
+| Median (P50) | The midpoint of the timeline distribution — half of all runs completed within this many days. The most neutral planning figure. |
+| *N*% Confidence | The duration that *N*% of runs completed within. This is the figure a planner should commit to when they want the programme to finish on time in *N*% of plausible outcomes. The label updates to reflect the current confidence setting. |
+| P90 (Worst Case) | The duration that 90% of runs fell below. A conservative upper bound for scheduling contingency. |
+
+### Relationship to Effort
+
+Timeline and effort are related but distinct. A programme can take longer on the calendar than effort alone would suggest because:
+
+- Parallel instances contend for shared weekly capacity, creating queuing delays
+- Wait time — external dependencies such as supplier responses or stakeholder reviews — adds calendar time without consuming team capacity
+
+A programme with modest total effort can still have a long calendar duration if weekly capacity is constrained or wait times are high. Both dimensions should be reviewed together. See [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait) and [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput).
+
+### Executive Summary
+
+The three timeline values most useful for stakeholder communication are paired with their corresponding effort values in the Executive Summary's Planning Scenarios card:
+
+| Scenario | Timeline value used |
+|---|---|
+| Most Likely Outcome | P50 |
+| Conservative Planning | *N*% Confidence |
+| Contingency Planning | P90 |
+
+See [Effort Analysis](./effort-analysis.md) for the effort values that appear alongside these.
+
+### Data Flow
+
+Timeline values are derived from the sorted array of total calendar duration outputs across all simulation runs. Percentiles are read by position in that sorted array. Calendar duration is measured in business days, converted from person-hours using the Hours per Work Day parameter.
+
+## Security Considerations
+
+All displayed values are numbers computed from simulation output. No user-supplied strings appear in this section.
+
+## Known Limitations
+
+- P10 is not displayed; the current design shows only P50, the confidence percentile, and P90.
+- Calendar duration is expressed in business days but does not account for specific calendars, holidays, or non-working periods.
+- The timeline distribution reflects scheduling under the weekly capacity constraint but does not model dependencies between instances — instances are assumed to be independent.
+
+## Future Enhancements
+
+- Add P10 to the grid to show the optimistic tail.
+- Allow the confidence level to be adjusted after the simulation has run.
+- Offer an option to display duration in calendar weeks rather than business days.
+
+## Related Documentation
+
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait)
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Report Structure](./report-structure.md)
+- [Effort Analysis](./effort-analysis.md)
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `confidence` and `hoursPerDay` parameters directly shape what this section displays

--- a/docs/features/03-report/workload-chart.md
+++ b/docs/features/03-report/workload-chart.md
@@ -1,0 +1,57 @@
+# Feature: Workload Chart
+
+## Overview
+
+The Weekly Workload chart shows the average hour-by-hour demand on the team across each week of the programme, for the subset of simulation runs near the chosen confidence level. Unlike the distribution charts — which show how total effort and duration vary across all runs — the workload chart shows the *shape* of demand over time within a representative set of outcomes: when the team will be busiest, and which weeks are likely to exceed the weekly capacity limit.
+
+## User Story
+
+As a capacity planner, I want to see how weekly demand is distributed across the programme's duration so that I can identify pressure points and judge whether the weekly capacity constraint is likely to be breached, and when.
+
+## Functionality
+
+### What the Chart Shows
+
+Each bar represents one week of the programme. Bar height is the average hours required in that week, taken across the confidence-band simulations. A horizontal reference line marks the weekly capacity limit entered in Simulation Settings.
+
+Bars are colour-coded by whether they exceed the weekly limit:
+- Bars within the weekly capacity limit are shown in amber
+- Bars that exceed it are shown in red
+
+### Confidence-Band Scope
+
+The chart is drawn from the subset of simulation runs whose total timeline falls near the chosen confidence-level percentile, rather than averaging across all runs. This reflects a deliberate design choice: averaging across all runs would blend short programmes with long ones, obscuring the week-by-week shape of any individual outcome. The confidence-band subset gives a realistic picture of what demand looks like in the planning scenario the user has committed to.
+
+The chart heading states the confidence level and the number of simulations that contributed to it.
+
+### Resource Requirements Summary
+
+The average weekly hours and peak weekly hours derived from this chart are also displayed in the Executive Summary's Resource Requirements card, providing a compact version of the same information for stakeholder communication.
+
+### What to Look For
+
+A chart where most bars are well below the reference line and no bars are red indicates the programme is unlikely to breach weekly capacity in the chosen planning scenario. A chart with several red bars — particularly consecutive ones — signals a sustained period of overload that may require rescheduling, additional resource, or scope reduction.
+
+The position of the peaks within the programme also matters: front-loaded demand means pressure early; back-loaded demand suggests the programme accelerates in later weeks.
+
+## Known Limitations
+
+- The chart covers weeks from the start of the programme to the maximum week across the confidence-band simulations. If individual runs in the band have very different durations, later weeks may average across a diminishing subset of active runs, making those bars less representative.
+- The weekly capacity reference line reflects the parameter value at the time of the run; if the value has been changed since, it will not match.
+- The chart shows average demand per week, not the full distribution of weekly demand. A week that averages at capacity may still exceed it in some of the contributing simulations.
+
+## Future Enhancements
+
+- Show a range band (e.g. P25–P75) around each weekly bar to convey the variability within the confidence-band simulations.
+- Allow the user to switch between the full-run average and the confidence-band view.
+- Add a second reference line at a lower "comfortable" capacity level to distinguish weeks that are merely busy from those that are genuinely at risk.
+
+## Related Documentation
+
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Foundation — Reading the Results](../../foundation.md#reading-the-results)
+- [Report Structure](./report-structure.md)
+- [Effort Analysis](./effort-analysis.md)
+- [Capacity Assessment](./capacity-assessment.md)
+- [Distribution Charts](./distribution-charts.md)
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `confidence` and `weeklyCapacity` parameters directly shape what this chart displays


### PR DESCRIPTION
## Summary

- Adds seven feature documents to `docs/features/03-report/`, which previously had no content
- Documents cover the full results report: structure, effort analysis, timeline analysis, capacity assessment, distribution charts, workload chart, and executive summary
- Written at product/behaviour level — no CSS classes, selectors, or function names; visual structure described with ASCII diagrams where appropriate

## Test plan

- [ ] Review each document for accuracy against the current application behaviour
- [ ] Check cross-links between documents resolve correctly
- [ ] Confirm the section table in `report-structure.md` matches the actual report layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)