### PR TITLE
docs: add feature documents for 04-exchange section

### DIFF
--- a/docs/features/04-exchange/csv-export.md
+++ b/docs/features/04-exchange/csv-export.md
@@ -1,0 +1,137 @@
+# Feature: CSV Export
+
+## Overview
+
+Allows a user to save the current task list as a CSV file. Clicking the export button downloads a file containing all named task rows in the application's standard CSV format. The file can be re-imported without modification and opened in common spreadsheet tools.
+
+## User Story
+
+As a capacity planner, I want to save my task list to a CSV file so that I can preserve my work, share it with colleagues, and reload it in a future session.
+
+## Functionality
+
+### Core Features
+
+- An "Export to CSV" button must download the current task list as a file named `timeline_planning_tasks.csv`
+- Only rows with a non-empty Task Name must be included in the export; rows without a name must be silently excluded
+- The exported file must conform to the format defined in [CSV File Format](./csv-file-format.md)
+- Task names beginning with formula-starter characters must be escaped before export to prevent formula injection when the file is opened in a spreadsheet application
+
+### User Interface
+
+An "Export to CSV" button appears above the task grid, alongside the file picker and "Load from File" button. Clicking it triggers an immediate browser download with no additional confirmation step or dialogue.
+
+### Data Flow
+
+1. The user clicks "Export to CSV"
+2. All task rows are read from the task grid; rows with an empty Task Name are excluded
+3. Task names are checked for formula-starter characters and escaped where necessary
+4. The row data is serialised to RFC 4180-conformant CSV with a header row and CRLF line endings
+5. The CSV content is offered to the browser as a file download named `timeline_planning_tasks.csv`
+6. The browser's native download mechanism handles the save location; the application does not retain or transmit the file content
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **Task grid content**: Task names and numeric values are read from form inputs. These values originate from user entry or CSV import and must be treated as untrusted when deciding how to serialise them.
+
+#### Outbound Data Vectors
+
+- **File download**: The exported CSV is written to the user's filesystem. If opened in a spreadsheet application, formula-starter task names could be interpreted as formulas unless escaped.
+
+#### Trust Boundaries
+
+- **Task grid to CSV**: Task names must be inspected for formula-starter characters before serialisation; names beginning with such characters must be escaped.
+- **Application to user's filesystem**: The download is initiated by a programmatically created anchor element; no content is sent to any server and no URL is retained after the download completes.
+
+### Threat Model
+
+- **Formula injection via exported file**: A task name beginning with `=`, `+`, `-`, `@`, tab, or carriage return would be interpreted as a formula by some spreadsheet applications when the file is opened → Mitigation: task names beginning with these characters must have a single quote prepended before serialisation.
+- **Data exfiltration**: The export mechanism could be exploited to send file content to an external server rather than the user's filesystem → Mitigation: the download uses a blob URL created and immediately revoked in the browser; no network request is involved.
+
+### Security Controls
+
+- Task names beginning with formula-starter characters must be prefixed with a single quote before serialisation
+- The download must use a browser-local blob URL that is revoked immediately after the download is initiated; no content must be transmitted to any server
+- Numeric fields are written as-is; they cannot contain formula-starter values
+
+## Configuration
+
+| Constant | Value | Purpose |
+|---|---|---|
+| Export filename | `timeline_planning_tasks.csv` | Fixed filename offered to the browser download dialogue |
+| Line ending | CRLF (`\r\n`) | RFC 4180 requirement for maximum spreadsheet compatibility |
+| Formula-starter characters | `=`, `+`, `-`, `@`, tab (`\t`), carriage return (`\r`) | Task names beginning with these must be escaped |
+| Escape prefix | `'` (single quote) | Prepended to formula-starter task names; stripped on re-import |
+
+## Usage Examples
+
+### Exporting the current task list
+
+1. Configure tasks and run the simulation
+2. Click "Export to CSV"
+3. The browser downloads `timeline_planning_tasks.csv`
+4. Open the file in a spreadsheet tool — all tasks appear as rows with correct column values
+
+### Round-trip: export then import
+
+1. Click "Export to CSV" to save the current task list
+2. Click the file picker, select the downloaded file, and click "Load from File"
+3. The task list is restored exactly as it was at the point of export
+
+## Validation & Error Handling
+
+Export requires no user-provided input and performs no validation that can fail. The only exclusion rule is that rows with an empty Task Name are omitted silently; no error or warning is shown for excluded rows.
+
+If the task grid contains no named rows, the exported file will contain only the header row. The download still proceeds; no error is shown.
+
+## Testing
+
+### Test Cases
+
+- A task list with three named rows exports a file containing a header row and three data rows
+- A task list containing a row with an empty Task Name exports without that row; no error is shown
+- A task list containing only unnamed rows exports a file with only the header row
+- A task name beginning with `=` is exported with a leading `'` and the raw CSV contains `'=`
+- A task name beginning with `'` followed by a formula-starter character is exported as `''=` (double single-quote)
+- A task name containing a comma is exported as a quoted field
+- A task name containing a double-quote is exported with the quote escaped as `""`
+- The exported file uses CRLF line endings
+- The exported filename is `timeline_planning_tasks.csv`
+- The download does not trigger a network request (verifiable via browser DevTools network panel)
+
+### Manual Testing Steps
+
+1. Enter a task named `=HYPERLINK("http://evil.example","x")` and export — open the downloaded CSV in Excel or Google Sheets and confirm the cell is not rendered as a hyperlink
+2. Enter a task with a comma in its name and export — open the file in a text editor and confirm the name is quoted
+3. Export and re-import — confirm the task list is identical to the original
+4. Export with an empty task grid — confirm the download still occurs and the file contains only the header row
+5. Open browser DevTools network panel, click Export — confirm no network request is made
+
+## Performance Considerations
+
+- All task rows are read from the DOM in a single pass; with a maximum of 100 rows this is negligible
+- The CSV is serialised in memory and written to a blob URL; no streaming or chunking is needed at this scale
+- The blob URL is revoked immediately after the download link is clicked, releasing the memory
+
+## Known Limitations
+
+- The exported filename is fixed as `timeline_planning_tasks.csv`; the user cannot choose a different name at export time (though they can rename it after download).
+- The export always captures the current state of the task grid at the moment of the click; any unsaved edits in progress are included.
+- In some browsers, the download may silently fail if the user's download folder is full or write-protected; no error is surfaced to the application.
+
+## Future Enhancements
+
+- Allow the user to specify a custom filename before exporting.
+- Show the number of rows included in the export as confirmation feedback after the download is initiated.
+
+## Related Documentation
+
+- [CSV File Format](./csv-file-format.md)
+- [CSV Import](./csv-import.md)
+- [Task Management](../01-configure/task-management.md)
+- [ADR: CSV Format](../../adr/standards/csv-format.md)
+- [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md)

--- a/docs/features/04-exchange/csv-file-format.md
+++ b/docs/features/04-exchange/csv-file-format.md
@@ -1,0 +1,139 @@
+# Feature: CSV File Format
+
+## Overview
+
+Task lists are stored and exchanged as CSV files conforming to RFC 4180. The format is designed to be readable and writable by common spreadsheet tools — Excel, Google Sheets, LibreOffice Calc — without data loss. A file exported by the application can be re-imported without any manual editing, and files produced by spreadsheet tools can be imported directly.
+
+## User Story
+
+As a capacity planner, I want a well-defined, portable file format for my task lists so that I can author or edit tasks in a spreadsheet tool and import them, and share exported files with colleagues using different tools.
+
+## Functionality
+
+### Core Features
+
+- The format must use a fixed eight-column schema with a mandatory header row
+- The format must conform to RFC 4180: comma-separated fields, CRLF line endings on export, both CRLF and LF accepted on import, quoted fields for values containing commas or double-quotes, `""` escaping for embedded double-quotes
+- Task names containing commas, double-quotes, apostrophes, and Unicode characters must survive a full export–import round-trip without modification
+- Task names beginning with characters that spreadsheet applications interpret as formula starters must be escaped on export and unescaped on import
+
+### User Interface
+
+This document specifies the file format, not user interactions. There are no UI elements associated with the format itself. UI elements for reading and writing files are defined in [CSV Import](./csv-import.md) and [CSV Export](./csv-export.md).
+
+### Data Flow
+
+On export, the application reads the task grid and serialises each named row into the eight-column schema. On import, the application parses the file according to the same schema and populates the task grid. The schema is the shared contract between the two operations; a file produced by either the application or a compatible spreadsheet tool must be acceptable to both.
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **File content**: A CSV file submitted for import may contain arbitrary text in the Task Name column, including strings crafted to trigger formula execution or XSS payloads. Numeric columns may contain non-numeric values.
+
+#### Outbound Data Vectors
+
+- **File downloads**: The exported CSV file is written to the user's filesystem. If opened in a spreadsheet application, task names beginning with formula-starter characters could be interpreted as formulas unless escaped.
+
+#### Trust Boundaries
+
+- **File content to application**: Imported CSV content must be treated as untrusted. Task names are free text and must be rendered to the DOM as plain text, not as markup.
+- **Application to spreadsheet tools**: Exported task names must be escaped to prevent formula injection when the file is opened in a spreadsheet application.
+
+### Threat Model
+
+- **Formula injection via exported file**: A task name beginning with `=`, `+`, `-`, `@`, tab, or carriage return would be interpreted as a formula by some spreadsheet applications when the exported CSV is opened → Mitigation: the application must prepend a single quote to any such task name on export; the quote must be stripped on re-import so round-tripping preserves the original name.
+- **XSS via imported task name**: A crafted task name containing HTML or script content is imported and later rendered to the DOM → Mitigation: task names must be set via DOM text assignment, never injected as HTML — see [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md).
+
+### Security Controls
+
+- Task names beginning with formula-starter characters must be prefixed with a single quote on export and have the prefix stripped on import
+- Task names must be rendered to the DOM as plain text at all times — see [CSV Import](./csv-import.md)
+- Numeric fields are not subject to formula injection and require no escaping
+
+## Configuration
+
+| Constant | Value | Purpose |
+|---|---|---|
+| Column headers | `Task Name`, `Skip %`, `Work Optimistic (hrs)`, `Work Expected (hrs)`, `Work Pessimistic (hrs)`, `Wait Optimistic (days)`, `Wait Expected (days)`, `Wait Pessimistic (days)` | Fixed header row; column order is significant |
+| Formula-starter characters | `=`, `+`, `-`, `@`, tab (`\t`), carriage return (`\r`) | Task names beginning with these must be escaped on export |
+| Escape prefix | `'` (single quote) | Prepended to formula-starter task names on export; stripped on import |
+
+## Usage Examples
+
+### Minimal valid file
+
+```csv
+Task Name,Skip %,Work Optimistic (hrs),Work Expected (hrs),Work Pessimistic (hrs),Wait Optimistic (days),Wait Expected (days),Wait Pessimistic (days)
+Supplier Security Review,0,8,32,96,0,2,5
+```
+
+### File with optional tasks and wait time
+
+```csv
+Task Name,Skip %,Work Optimistic (hrs),Work Expected (hrs),Work Pessimistic (hrs),Wait Optimistic (days),Wait Expected (days),Wait Pessimistic (days)
+Supplier Security Review,0,8,32,96,0,2,5
+Vulnerability Assessment,0,24,64,120,1,3,7
+Supplier Follow-up,60,8,24,64,0,1,3
+```
+
+### Task name requiring formula escaping (as it appears in the exported file)
+
+```csv
+'=SUM(A1:A10),0,8,16,32,0,0,0
+```
+
+The leading `'` is stripped on re-import; the task name is restored to `=SUM(A1:A10)`.
+
+## Validation & Error Handling
+
+A row is considered valid for import if it has a non-empty Task Name and at least eight columns. Rows failing this check are silently skipped — they do not block the import of other rows. Invalid numeric values are passed through to the task grid as-is; the simulation engine handles degenerate values.
+
+The file as a whole is rejected before any rows are loaded if the total number of valid rows exceeds the task limit — see [CSV Import](./csv-import.md).
+
+## Testing
+
+### Test Cases
+
+- A task name containing a comma round-trips correctly (export then import preserves the name)
+- A task name containing a double-quote round-trips correctly
+- A task name beginning with `=` is exported with a leading `'` and re-imported without it
+- A task name beginning with `'=` (genuine apostrophe followed by `=`) is exported as `''=` and re-imported as `'=`
+- A task name beginning with a plain apostrophe not followed by a formula-starter character is not modified on export or import
+- A file using LF line endings imports correctly
+- A file using CRLF line endings imports correctly
+- A row with an empty Task Name is excluded from import without error
+- A row with fewer than eight columns is excluded from import without error
+
+### Manual Testing Steps
+
+1. Enter a task named `=HYPERLINK("http://evil.example","Click me")` and export — open the exported file in a spreadsheet application and confirm the cell is not rendered as a hyperlink
+2. Export a task list, open the CSV in a text editor, confirm CRLF line endings and a correct header row
+3. Edit a task name in the exported CSV to include a comma, save, and re-import — confirm the name appears correctly in the task grid
+4. Re-import an exported file without modification — confirm the task list is identical to the original
+
+## Performance Considerations
+
+The format specification itself imposes no performance requirements. File size limits and parse time constraints are concerns of the import process; see [CSV Import](./csv-import.md).
+
+## Known Limitations
+
+- The column order is fixed; files with columns in a different order or with additional columns will import with incorrect field mapping.
+- The format carries no version indicator. If the schema changes in a future release, existing files may import incorrectly without a clear error message.
+- Locale-specific decimal separators (e.g. `,` instead of `.` for European locales) produced by some spreadsheet tools will cause numeric fields to import incorrectly.
+- Encoding is assumed to be UTF-8. Files saved with other encodings (e.g. Windows-1252 from older versions of Excel) may produce garbled task names for non-ASCII characters.
+
+## Future Enhancements
+
+- Add a version header row or comment to allow future schema changes to be detected and handled gracefully.
+- Detect and reject files with locale-specific decimal separators, with a clear error message directing the user to resave the file with the correct locale settings.
+
+## Related Documentation
+
+- [CSV Import](./csv-import.md)
+- [CSV Export](./csv-export.md)
+- [Task Management](../01-configure/task-management.md) — the task schema the format represents
+- [ADR: CSV Format](../../adr/standards/csv-format.md) — rationale for RFC 4180 and PapaParse
+- [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md)

--- a/docs/features/04-exchange/csv-import.md
+++ b/docs/features/04-exchange/csv-import.md
@@ -1,0 +1,158 @@
+# Feature: CSV Import
+
+## Overview
+
+Allows a user to load a task list from a CSV file into the task grid, replacing the current tasks. The file must conform to the application's CSV schema. Several validation checks run before any tasks are loaded, so the existing task list is never partially replaced.
+
+## User Story
+
+As a capacity planner, I want to load a previously saved task list from a CSV file so that I can resume work on a programme without re-entering tasks manually.
+
+## Functionality
+
+### Core Features
+
+- A file picker must allow the user to select a CSV file from their local filesystem
+- The selected file must pass a series of validation checks before any content is loaded
+- If validation passes, the current task list must be replaced in full with the tasks from the file
+- If validation fails at any point, the existing task list must be left unchanged and an error message must be shown
+- Rows with an empty Task Name or fewer than eight columns must be silently skipped; they must not block the import of other rows
+- Task names escaped for formula injection on export must be unescaped on import, restoring the original name — see [CSV File Format](./csv-file-format.md#formula-injection-handling)
+
+### User Interface
+
+A file picker and a "Load from File" button appear above the task grid. The user selects a file using the picker and then clicks the button to trigger the import. There is no drag-and-drop target; selection must be done through the browser's native file dialogue.
+
+### Data Flow
+
+1. The user selects a file and clicks "Load from File"
+2. The file is validated against extension, MIME type, and size constraints before any content is read
+3. The file content is read as UTF-8 text
+4. The content is parsed according to the RFC 4180 rules defined in [CSV File Format](./csv-file-format.md)
+5. Parsed rows are filtered to retain only those with a non-empty Task Name and at least eight columns
+6. If the number of valid rows exceeds the task limit, the import is rejected and the existing task list is preserved
+7. Otherwise, the task grid is cleared and each valid row is added as a new task row
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **File upload**: The user selects a file from their local filesystem. The file name, MIME type, and content are all supplied by the user and must be treated as untrusted.
+- **File content**: Task names may contain arbitrary strings, including HTML, script content, and formula-starter characters.
+
+#### Outbound Data Vectors
+
+- **DOM rendering**: Task names from the imported file are written into the task grid. They must be set as plain text, never as HTML.
+
+#### Trust Boundaries
+
+- **File to application**: File extension, MIME type, and size must all be validated before the file is read. File content must be parsed by a conformant RFC 4180 parser and must not be evaluated or executed.
+- **Parsed content to DOM**: Task names must be assigned to input values via the DOM API, not injected as markup — see [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md).
+
+### Threat Model
+
+- **Malicious file content (XSS)**: A crafted task name containing `<script>` tags or event handler syntax is imported and written to the DOM → Mitigation: task names must be set via `input.value` assignment, which the browser treats as plain text regardless of content.
+- **Resource exhaustion via large file**: An oversized file causes the browser to stall while reading → Mitigation: files larger than 1 MB must be rejected before the content is read.
+- **Task limit bypass via file import**: A file containing more than 100 valid rows causes the application to exceed its task count limit → Mitigation: the import must be rejected in full if valid row count exceeds the limit; the existing task list must be preserved.
+- **MIME type spoofing**: A non-CSV file is given a `.csv` extension to pass the extension check → Mitigation: both extension and MIME type are checked where the browser provides a MIME type; content is still parsed as CSV regardless of actual structure.
+
+### Security Controls
+
+- File extension must end in `.csv`
+- MIME type, when provided by the browser, must be one of the permitted CSV types
+- File size must not exceed 1 MB
+- Valid row count must not exceed 100 before any tasks are loaded
+- Task names must be rendered to the DOM as plain text — see [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md)
+- Formula-injection prefixes added on export must be stripped on import using the inverse of the export escaping scheme
+
+## Configuration
+
+| Constant | Value | Purpose |
+|---|---|---|
+| Maximum file size | 1 MB | Prevents resource exhaustion from oversized files |
+| Permitted MIME types | `text/csv`, `text/plain`, `application/csv`, `application/vnd.ms-excel` | Accepted content types alongside the `.csv` extension check |
+| Maximum task rows | 100 | Import is rejected in full if valid row count exceeds this limit |
+
+## Usage Examples
+
+### Loading a saved task list
+
+1. Click the file picker and select `timeline_planning_tasks.csv`
+2. Click "Load from File"
+3. The current task list is replaced with the tasks from the file
+4. The simulation re-runs automatically with the imported tasks
+
+### Recovering from a rejected import
+
+1. Click the file picker and select a file with 150 valid task rows
+2. Click "Load from File"
+3. An error message reports that the file contains too many tasks
+4. The existing task list remains unchanged
+
+## Validation & Error Handling
+
+Validation runs in the following order, stopping at the first failure:
+
+| Check | Failure response |
+|---|---|
+| A file has been selected | Alert: "Please select a file first" |
+| File name ends in `.csv` | Alert: "Invalid file type. Please upload a CSV file (.csv)." |
+| MIME type is permitted (when provided) | Alert: "Invalid file type. Please upload a CSV file." |
+| File size does not exceed 1 MB | Alert: "File is too large (*N* KB). Please upload a CSV file smaller than 1 MB." |
+| Valid row count does not exceed 100 | Alert: "This file contains *N* tasks, which exceeds the limit of 100. Please reduce the number of tasks in the file and try again." |
+
+If all checks pass, the import proceeds. Rows with an empty Task Name or fewer than eight columns are silently skipped; no error is shown for individual invalid rows.
+
+## Testing
+
+### Test Cases
+
+- A valid CSV file with three tasks imports correctly and replaces the current task list
+- A file with no extension other than `.csv` (e.g. `.txt`) is rejected before content is read
+- A file larger than 1 MB is rejected before content is read
+- A file with 101 valid rows is rejected; the existing task list is unchanged
+- A file with 100 valid rows and additional invalid rows imports the 100 valid rows only
+- A task name containing `<img src=x onerror=alert(1)>` imports without triggering the handler
+- A task name exported with a formula-injection prefix (`'=`) is imported as `=` (prefix stripped)
+- A row with an empty Task Name is excluded; no error is shown and other rows are imported
+- A row with fewer than eight columns is excluded; no error is shown and other rows are imported
+- Cancelling the file picker without selecting a file and clicking "Load from File" shows the "Please select a file first" alert
+
+### Manual Testing Steps
+
+1. Export the default task list, then immediately re-import it — confirm the task list is identical
+2. Select a `.txt` file — confirm the error alert fires and no tasks change
+3. Select a CSV file larger than 1 MB — confirm the size-limit alert fires
+4. Prepare a CSV with 101 valid rows and import it — confirm the task-limit alert fires and the existing tasks are unchanged
+5. Enter a task named `<script>alert(1)</script>`, export, re-import — confirm no alert fires and the name appears as plain text in the task grid
+6. Enter a task named `=HYPERLINK("http://evil.example","x")`, export, re-import — confirm the name round-trips correctly and no formula executes
+
+## Performance Considerations
+
+- Files are read in full before parsing begins; a 1 MB limit bounds the maximum memory used during a single import operation
+- Parsing and row validation are O(n) in the number of rows; with a maximum of 100 valid rows the parse time is negligible
+- The task grid is cleared and rebuilt in a single pass after validation; there is no incremental rendering
+
+## Known Limitations
+
+- There is no progress indicator during file reading; for files approaching the 1 MB limit the browser may appear unresponsive briefly.
+- MIME type checking depends on the browser providing a type; some browsers report an empty MIME type for `.csv` files, in which case only the extension check applies.
+- Files saved with non-UTF-8 encodings (e.g. Windows-1252) will import without error but non-ASCII characters may be garbled.
+- The import replaces the entire task list; there is no merge or append option.
+
+## Future Enhancements
+
+- Add an append mode that adds imported tasks to the existing list rather than replacing it.
+- Show a preview of the tasks to be imported before committing, allowing the user to confirm or cancel.
+- Detect and report non-UTF-8 encoding with a clear error message.
+
+## Related Documentation
+
+- [CSV File Format](./csv-file-format.md)
+- [CSV Export](./csv-export.md)
+- [Task Management](../01-configure/task-management.md)
+- [Simulation Complexity Limits](../02-simulate/simulation-complexity-limits.md) — the 100-task limit applies equally to import and manual entry
+- [ADR: CSV Format](../../adr/standards/csv-format.md)
+- [ADR: DOM XSS Prevention](../../adr/security/dom-xss-prevention.md)


### PR DESCRIPTION
## Summary

- Adds three feature documents to `docs/features/04-exchange/`, which previously had no content
- Covers the CSV file format specification, import flow, and export flow
- Each document follows the feature template in full; sections that don't apply include an explanation of why rather than being omitted

## Test plan

- [ ] Review each document for accuracy against the current application behaviour
- [ ] Check cross-links between documents and to ADRs resolve correctly
- [ ] Confirm security considerations cover formula injection and XSS mitigations consistently across all three docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)