### PR TITLE
docs: add feature documents for the 02-simulate section

### DIFF
--- a/docs/features/02-simulate/capacity-constrained-scheduling.md
+++ b/docs/features/02-simulate/capacity-constrained-scheduling.md
@@ -1,0 +1,216 @@
+# Feature: Capacity-Constrained Scheduling
+
+## Overview
+
+After effort values are sampled for each task in each programme instance, the scheduler places all work items into a shared calendar subject to the weekly capacity constraint. Work items are positioned at the earliest available slot that does not exceed the weekly capacity limit; items that cannot fit in a given week are pushed forward until capacity is available. Tasks that require more than one day's worth of capacity are split into sub-day chunks before scheduling so that each chunk fits within a single day. The final timeline for a simulation run is the day when the last item finishes, including any trailing wait time.
+
+## User Story
+
+As a capacity planner, I want the simulation to model the scheduling impact of limited weekly capacity so that the timeline output reflects how long the work will actually take when the team can only contribute a fixed number of hours per week — not just how many person-hours are required in total.
+
+## Functionality
+
+### Why Scheduling Matters
+
+Total effort and calendar duration are related but different. A programme requiring 400 person-hours could complete in ten weeks at 40 hours per week, or twenty weeks at 20 hours per week, even though the effort is the same. When multiple parallel instances share the same weekly capacity, contention for that capacity further stretches the calendar. The scheduler models this explicitly: each simulation run produces a timeline that reflects when all work can realistically be completed, not just how much work there is.
+
+### Task Chunking
+
+Before scheduling, each work item is compared against the daily capacity limit — the maximum hours that can be completed in a single working day, derived from the weekly capacity and a five-day working week. If a task's sampled effort exceeds this limit, it is split into a sequence of chunks, each no larger than the daily limit.
+
+Chunking preserves the task's total effort. A 20-hour task with a daily limit of 8 hours produces three chunks: 8 hours, 8 hours, and 4 hours. The chunks are scheduled sequentially — a later chunk cannot begin until the preceding chunk has completed.
+
+Wait time is associated with the final chunk only. If a task is split, the wait period begins after the last chunk of work is done, not after each intermediate chunk.
+
+Tasks that fit within the daily capacity are not chunked.
+
+### Capacity Allocation
+
+All work items from all programme instances in a single run share one weekly capacity pool. The scheduler tracks how many hours have been allocated in each week across all instances combined. Before placing a work item, it checks whether the item fits within the remaining capacity for the weeks it would occupy.
+
+Work that spans a week boundary has its hours distributed proportionally across the weeks it touches, based on how many working days fall in each. A task beginning on Thursday and completing the following Tuesday would have roughly two-fifths of its hours counted against the first week and three-fifths against the second.
+
+### Placement and Deferral
+
+Each work item is placed at its earliest permissible start day — the later of the item's natural start (when the previous task in the same series finished) and the day its preceding chunk completed. The scheduler then checks whether the weekly capacity allows placement there:
+
+- If there is sufficient capacity, the item is placed and the weekly usage is updated
+- If there is insufficient capacity, the start day is advanced and the check is repeated:
+  - Small items that fit within a single day are advanced by one day at a time
+  - Larger items are advanced to the start of the next complete week
+
+This continues until a valid slot is found or a fallback limit is reached.
+
+### Fallback for Heavily Constrained Configurations
+
+If a valid slot cannot be found within a fixed number of advancement attempts, the item is placed at the current candidate start day regardless of capacity. This prevents the scheduler from looping indefinitely when the configuration is severely oversubscribed (for example, a large number of parallel instances relative to weekly capacity). The placed item will exceed the weekly capacity limit for that week; the resulting timeline is still recorded, but the weekly hours in the affected weeks will be above the configured limit.
+
+This condition is most likely to arise when the complexity budget warning has been dismissed and the run involves a very high programme quantity. The workload chart will show the oversubscribed weeks in red.
+
+### Wait Time and the Timeline
+
+Wait time is calendar time during which the team is not working on a task — an external review, a stakeholder response, or a scheduled pause. After a task's work chunks are all placed, the wait time is added to determine when the *next* task in the same series can begin. Wait time does not consume capacity; other series can use that capacity freely during the wait period.
+
+The total timeline for a run is the latest day across all scheduled items, where each item's contribution is its scheduled completion day plus its associated wait time.
+
+### Task and Series Ordering
+
+Within a programme instance (series), tasks execute in the order they appear in the task grid. Task N in a series cannot begin until task N-1 is fully complete, including its wait time. There is no parallel execution within a single series.
+
+Across series, work is interleaved freely — the scheduler places items from all series into the shared capacity pool, and items from different series may occupy the same week. The order in which series are processed follows their index, but the greedy placement approach means earlier series do not have a meaningful scheduling advantage over later ones in most configurations.
+
+### Data Flow
+
+For each simulation run:
+
+1. Effort sampling produces a work effort (hours) and wait time (days) for each non-skipped task in each series
+2. Tasks exceeding the daily capacity limit are split into chunks; others remain whole
+3. All work items — chunks and whole tasks — across all series are sorted by series, task order within the series, and chunk order within the task
+4. Each item is placed at the earliest available slot that fits within the weekly capacity; if no slot is found within the attempt limit, the item is placed at the current candidate position
+5. After each item is placed, the weekly usage map is updated and the series's progress marker is advanced
+6. Once all items are placed, the total timeline is read as the maximum scheduled completion day plus any trailing wait time across all items
+7. The resulting schedule is stored alongside the timeline for use by the workload chart
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **Sampled effort values**: Work effort and wait time values arrive from the effort sampling stage as numbers. No user-supplied strings are involved at this stage.
+- **Simulation parameters**: Weekly capacity and hours per day are parsed from numeric form fields before reaching the scheduler.
+
+#### Outbound Data Vectors
+
+- **Scheduled timeline**: The timeline value is a number (days). It contributes to the sorted results array and is later rendered as a formatted decimal string in the report.
+- **Work schedule**: The schedule produced for each run is a numeric data structure used to generate the workload chart. No user-supplied strings are carried into chart rendering.
+
+#### Trust Boundaries
+
+- **Effort sampling to scheduler**: Only numeric values (hours, days, indices) cross this boundary. No string content is forwarded.
+
+### Threat Model
+
+- **Infinite loop via adversarial inputs**: A very high programme quantity relative to weekly capacity could cause the placement loop to run for a very long time → Mitigation: a fixed attempt limit ensures the loop terminates; the item is placed unconditionally once the limit is reached.
+- **Numeric overflow via extreme values**: Very large effort values or very high programme quantities could produce very large timeline numbers → Mitigation: JavaScript numbers handle values well beyond any realistic planning input; no clamping is required.
+
+### Security Controls
+
+- The placement loop must terminate unconditionally within a fixed number of attempts, regardless of input values.
+- All scheduled values must be numbers; no user-supplied strings must be included in the work schedule passed to the chart.
+
+## Configuration
+
+| Parameter | Source | Role in scheduling |
+|---|---|---|
+| Max Weekly Capacity (hrs) | Simulation Settings | The total hours available per week across all series; the primary constraint |
+| Hours per Work Day | Simulation Settings | Used to convert person-hours to working days, and to derive the daily capacity limit for chunking |
+| Program Quantity | Simulation Settings | Determines how many series compete for the shared weekly capacity |
+
+The daily capacity limit used for chunking is derived from weekly capacity divided by five and is not separately configurable.
+
+## Usage Examples
+
+### Single instance, well within capacity
+
+```text
+Weekly capacity: 40 hrs
+Programme quantity: 1
+Tasks: 3 tasks, sampled efforts of 12, 20, and 8 hours (daily limit: 8 hrs)
+
+Task 1 (12 hrs, 2 chunks):  chunk 1 → days 0–1, chunk 2 → days 1–2.5
+Task 2 (20 hrs, 3 chunks):  placed sequentially after task 1
+Task 3 (8 hrs, 1 chunk):    placed after task 2
+
+Each week stays well within 40 hrs; no deferral needed.
+```
+
+### Multiple instances competing for capacity
+
+```text
+Weekly capacity: 40 hrs
+Programme quantity: 5
+Each instance: 3 tasks totalling ~40 hours sampled effort
+
+Week 1: instances 1–3 fill the 40-hour pool; instances 4–5 are deferred to week 2
+Week 2: deferred work from instances 4–5 is placed; further tasks from all instances compete
+Timeline is longer than (total effort / weekly capacity) would suggest, due to contention.
+```
+
+### Wait time extending the calendar
+
+```text
+Task: 8 hrs work (placed in week 1), 10 days wait
+Next task in same series: earliest start is day 10 (8 hrs / 8 hrs per day + 10 days wait = day 11)
+
+During days 1–11, the team's capacity is free for other series.
+The calendar duration of the series extends by 10 days; total effort is unaffected.
+```
+
+### Fallback placement for an oversubscribed configuration
+
+```text
+Weekly capacity: 10 hrs
+Programme quantity: 20
+Many items contend for a small weekly pool.
+
+After the attempt limit is exhausted for a given item, the item is placed
+at the current candidate position even though that week is already at capacity.
+The workload chart will show the affected weeks in red.
+```
+
+## Validation & Error Handling
+
+- The placement loop must not run indefinitely; it must terminate at the attempt limit and force placement at the current position
+- A work item with zero or negative hours must be treated as schedulable immediately without consuming any capacity
+- If a run produces no scheduled items (all tasks were skipped), the timeline must be handled gracefully — the maximum of an empty set must not cause an error
+
+## Testing
+
+### Test Cases
+
+- A task requiring more than one day's capacity is split into chunks whose individual hours each fit within the daily limit
+- Chunks of the same task are scheduled sequentially; the second chunk does not begin before the first ends
+- Wait time does not appear in the weekly capacity usage — weeks during a wait are not marked as consumed
+- With a single instance and generous capacity, the total timeline matches effort divided by hours per day plus any wait time (no deferral)
+- With high programme quantity relative to weekly capacity, the timeline is longer than effort alone would imply
+- After the attempt limit is reached, the scheduler places the item rather than looping further
+- The timeline is computed as the latest scheduled completion plus trailing wait, not just the latest scheduled completion
+
+### Manual Testing Steps
+
+1. Set weekly capacity to 8 hrs and hours per day to 8, add one task with work effort 40 / 40 / 40 hrs, run — confirm the timeline is approximately 5 days (five chunks of 8 hrs across five consecutive days)
+2. Set programme quantity to 10, same configuration — confirm the timeline increases relative to a single instance, reflecting capacity contention
+3. Add a task with a wait of 0 / 10 / 10 days and a second task after it, run — confirm the second task's start is delayed by the wait period of the first
+4. Set weekly capacity to 8 hrs and programme quantity to 20, run — confirm the simulation completes and results are produced (no hang); check the workload chart for red bars indicating oversubscribed weeks
+
+## Performance Considerations
+
+- Scheduling is O(n²) in the worst case due to the linear scan over placed items when resolving chunk predecessors; for typical task counts (tens to low hundreds of items per run) this is not a concern
+- The attempt limit bounds the per-item placement cost; no item can cause more than that many iterations regardless of configuration
+- The weekly usage map is keyed by week number and allocated lazily; it imposes no cost for weeks with no work
+
+## Known Limitations
+
+- Working weeks are modelled as five consecutive days; there is no representation of public holidays, part-week schedules, or irregular capacity patterns
+- The scheduler is greedy: each item is placed as early as possible. It does not globally optimise for minimum timeline or even load distribution. A different task ordering could sometimes produce a shorter timeline
+- Tasks execute in the order they appear in the task grid. There is no way to specify that a task may overlap with the preceding one, or to mark a dependency that skips intermediate tasks
+- The attempt limit means that heavily oversubscribed configurations can silently exceed the weekly capacity for some weeks; the workload chart is the only signal that this has occurred
+- The daily capacity limit for chunking is always weekly capacity divided by five. There is no way to specify a different daily limit independently
+
+## Future Enhancements
+
+- Support non-uniform weekly capacity (e.g. weeks with holidays, ramp-up periods, or variable team availability)
+- Expose the placement attempt limit as a configuration option for users running extreme programme quantities
+- Investigate whether a smarter placement strategy (e.g. earliest-deadline-first) would reduce timeline variance across runs
+
+## Related Documentation
+
+- [Foundation — Capacity: Budget and Throughput](../../foundation.md#capacity-budget-and-throughput)
+- [Foundation — Programme Quantity](../../foundation.md#programme-quantity)
+- [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait)
+- [Effort Sampling](./effort-sampling.md) — produces the work effort and wait time values that this feature schedules
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `weeklyCapacity`, `hoursPerDay`, and `programQuantity` parameters that govern the scheduler
+- [Timeline Analysis](../03-report/timeline-analysis.md) — the report section that presents the timeline distribution produced by this feature
+- [Workload Chart](../03-report/workload-chart.md) — visualises the week-by-week capacity usage produced by the schedule
+- [Simulation Engine Property-Based Tests](../90-testing/simulation-engine-property-based-tests.md) — tests that verify scheduling invariants across random inputs

--- a/docs/features/02-simulate/effort-sampling.md
+++ b/docs/features/02-simulate/effort-sampling.md
@@ -1,0 +1,186 @@
+# Feature: Effort Sampling
+
+## Overview
+
+On each simulation run, every task produces a sampled work effort and a sampled wait time by drawing independently from a PERT distribution fitted to the task's three-point estimates. Tasks with a non-zero skip probability may be omitted entirely in a given run, contributing neither work nor wait. The same sampling mechanism applies to both work effort and wait time, and each task in each programme instance is sampled independently.
+
+## User Story
+
+As a capacity planner, I want the simulation to draw realistic effort values from the range I described so that the distribution of outcomes reflects the true uncertainty in my estimates — clustering near the most likely outcome but preserving the tail of difficult scenarios.
+
+## Functionality
+
+### PERT Distribution Sampling
+
+For each non-skipped task in each run, both work effort and wait time are sampled from a PERT distribution fitted to the task's three-point estimates.
+
+The PERT distribution is a scaled Beta distribution. Its key property is that outcomes cluster around a weighted mean — `(optimistic + 4 × expected + pessimistic) / 6` — rather than around the arithmetic midpoint of the range. This gives the expected estimate four times the weight of the extreme estimates, reflecting the assumption that the expected case is the most carefully considered. The result is a distribution that:
+
+- Produces outcomes within the [optimistic, pessimistic] range
+- Has its mode at the expected value
+- Has an asymmetric tail toward the pessimistic end when the expected value is closer to optimistic than to pessimistic
+
+Work effort and wait time for the same task are sampled independently. A run may produce a low work effort and a high wait time for the same task, or any other combination.
+
+### Skip Logic
+
+When a task has a non-zero skip percentage, a random check is performed at the start of each task evaluation for each programme instance in each run. If the check indicates the task is skipped:
+
+- The task contributes **zero work effort** and **zero wait time** for that instance
+- The task is absent from the schedule for that instance
+- No PERT sampling occurs for that instance
+
+The skip check is independent for every instance in a multi-quantity run. In a run with ten parallel instances, a task with a 60% skip probability will typically be absent from around six of the ten instances, with the exact count varying by run.
+
+### Work Effort vs. Wait Time
+
+Work effort and wait time are sampled by the same mechanism but represent different things downstream:
+
+| Component | Unit | What it affects |
+|---|---|---|
+| Work effort | Person-hours | Consumes team capacity; counts toward total effort; drives the effort distribution |
+| Wait time | Days | Adds calendar duration for that instance; does not consume capacity |
+
+For the conceptual distinction between work effort and wait time, see [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait).
+
+### Zero and Inverted Ranges
+
+When the pessimistic estimate equals the optimistic estimate (range is zero), no distribution can be fitted. The expected value is returned directly, and no random sampling occurs.
+
+When the pessimistic estimate is less than the optimistic estimate (an inverted range), the same applies: the expected value is returned. An inverted range is accepted without error; the result is deterministic for that task.
+
+### Extreme PERT Ratios
+
+When the expected value is very close to one end of the optimistic–pessimistic range, the fitted Beta distribution parameters become small. Parameters below a safe threshold are raised to that threshold before sampling. This keeps the distribution well-behaved at the cost of a slight shift relative to what a strict PERT parameterisation would produce for highly skewed inputs. In practice this matters only when the expected value is extremely close to the optimistic or pessimistic bound.
+
+### Data Flow
+
+For each series (programme instance) in each simulation run:
+
+1. Each task is evaluated in order
+2. If the task has a skip percentage, a random check determines whether the task is present in this instance
+3. For a present task, work effort is sampled from the PERT distribution fitted to the work estimates
+4. Wait time is sampled from the PERT distribution fitted to the wait estimates
+5. The sampled work effort is passed to the scheduler; the sampled wait time is used to delay the earliest start of the next task in the same series
+6. The work effort accumulates into the run's total effort figure
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- **Numeric task inputs**: Optimistic, expected, and pessimistic values are parsed from numeric form fields. They arrive as numbers, not strings.
+
+#### Outbound Data Vectors
+
+- **Simulation results**: Sampled values contribute to numeric result arrays. They are not rendered to the DOM directly; they flow through the results calculation and appear as formatted numbers in the report.
+
+#### Trust Boundaries
+
+- **Form inputs to simulation engine**: By the time task estimates reach the sampling logic, they have been parsed to numbers. No string content is carried through.
+
+### Threat Model
+
+- **Numerical instability via extreme inputs**: An adversarially chosen set of estimates (e.g. pessimistic far larger than expected) could push the Beta distribution parameters to very small values → Mitigation: parameters are raised to a safe minimum before sampling, keeping the distribution well-behaved regardless of input values.
+- **Infinite loop in distribution sampling**: The Beta distribution is generated via a rejection-sampling algorithm; pathological inputs could theoretically cause many rejections → Mitigation: the safe minimum on distribution parameters ensures the algorithm converges in a small number of iterations for any valid input.
+
+### Security Controls
+
+- Distribution parameters must be raised to a safe minimum before sampling to prevent numerical instability for any combination of three-point estimates.
+- Sampled values must not be written directly to the DOM; they must flow through the results computation and be rendered as formatted numeric strings.
+
+## Configuration
+
+This feature introduces no user-configurable constants. The safe minimum for Beta distribution parameters is an internal implementation detail, not a tunable value.
+
+## Usage Examples
+
+### A task with moderate uncertainty
+
+```text
+Work: Optimistic 8 hrs / Expected 24 hrs / Pessimistic 64 hrs
+Wait: Optimistic 1 day / Expected 3 days / Pessimistic 10 days
+Skip: 0%
+```
+
+Each run draws a work effort from roughly 8–64 hours, with the distribution clustering near the PERT mean of 27 hours. Wait time is drawn independently from 1–10 days, clustering near 3.5 days. Both components vary between runs.
+
+### A task with a skip probability
+
+```text
+Work: Optimistic 4 hrs / Expected 8 hrs / Pessimistic 24 hrs
+Wait: Optimistic 0 days / Expected 0 days / Pessimistic 0 days
+Skip: 60%
+```
+
+In roughly 60% of runs (per programme instance), this task is absent entirely — contributing no hours and no wait. In the remaining 40% of runs it contributes a sampled work effort drawn from 4–24 hours.
+
+### A deterministic task
+
+```text
+Work: Optimistic 8 hrs / Expected 8 hrs / Pessimistic 8 hrs
+```
+
+Because the range is zero, all three estimates are equal and every run returns exactly 8 hours for this task. No random sampling occurs.
+
+### A task with an inverted range
+
+```text
+Work: Optimistic 40 hrs / Expected 20 hrs / Pessimistic 10 hrs
+```
+
+The pessimistic estimate is less than the optimistic estimate. The range is treated as zero and the expected value — 20 hours — is returned every run. No warning is shown; the task behaves deterministically.
+
+## Validation & Error Handling
+
+- A zero or negative range must be detected before sampling; the expected value must be returned directly without attempting to fit a distribution
+- An inverted range (pessimistic less than optimistic) must be treated identically to a zero range
+- Distribution parameters must be raised to a safe minimum before any sampling call; the sampling algorithm must not be invoked with parameters that could cause numerical instability
+- Tasks with missing work estimates are excluded from the simulation run before sampling is attempted — see [Task Management](../01-configure/task-management.md)
+
+## Testing
+
+### Test Cases
+
+- A task with a wide range produces different effort values across repeated runs
+- A task with optimistic equal to pessimistic returns the expected value on every run
+- A task with a 100% skip rate (if permitted by the UI) is never present in any run
+- A task with a 0% skip rate is always present
+- Work effort and wait time for the same task are not identical across runs (i.e. they are sampled independently)
+- A task with a very skewed range (expected close to optimistic) does not produce errors or infinite loops
+- An inverted range (pessimistic less than optimistic) returns the expected value
+
+### Manual Testing Steps
+
+1. Add a single task with a wide range (e.g. Work O/E/P: 1 / 10 / 100 hrs), run 1,000 simulations, and confirm the effort distribution chart shows a spread of outcomes rather than a single spike
+2. Set all three work estimates to the same value (e.g. 8 / 8 / 8), run, and confirm the effort distribution chart shows a narrow spike at that value
+3. Set a task's skip percentage to 60%, run 1,000 simulations, and confirm the effort chart shows a spike at zero (skipped runs) alongside the distribution of active runs
+4. Set a task's pessimistic estimate below its optimistic estimate, run, and confirm no error occurs and results are produced
+
+## Performance Considerations
+
+- Sampling is O(1) per task per run; the total sampling cost scales with `simulations × programQuantity × tasks`
+- The rejection-sampling algorithm used for Beta distribution generation typically completes in a small number of iterations. Safe parameter bounds ensure it does not degrade for any valid input
+- No caching or pre-computation of distribution parameters occurs between runs; each run samples afresh
+
+## Known Limitations
+
+- For highly skewed three-point estimates (expected very close to optimistic or pessimistic), the safe minimum on Beta distribution parameters shifts the effective distribution slightly away from what strict PERT parameterisation would produce
+- An inverted range is accepted without warning and treated as a zero-range deterministic task; the user is not notified that their estimates may be misconfigured — see [Task Management — Known Limitations](../01-configure/task-management.md#known-limitations)
+- Work effort and wait time are sampled independently. In reality they may be correlated for some task types (a task that takes longer to complete may also wait longer for a response). This correlation is not modelled.
+
+## Future Enhancements
+
+- Warn when a task has an inverted range so users can identify misconfigured estimates
+- Support alternative distribution shapes (triangular, uniform) for users whose uncertainty does not fit the PERT model
+- Allow correlation to be specified between work effort and wait time for tasks where the two are expected to co-vary
+
+## Related Documentation
+
+- [Foundation — Three-Point Estimation](../../foundation.md#three-point-estimation)
+- [Foundation — Tasks: Work and Wait](../../foundation.md#tasks-work-and-wait)
+- [Foundation — Optional Tasks](../../foundation.md#optional-tasks)
+- [Task Management](../01-configure/task-management.md) — where three-point estimates and skip percentages are entered
+- [Capacity-Constrained Scheduling](./capacity-constrained-scheduling.md) — how the sampled work effort values are placed into a calendar schedule
+- [Simulation Engine Property-Based Tests](../90-testing/simulation-engine-property-based-tests.md) — tests that verify sampling invariants across random inputs

--- a/docs/features/02-simulate/simulation-progress.md
+++ b/docs/features/02-simulate/simulation-progress.md
@@ -1,0 +1,161 @@
+# Feature: Simulation Progress
+
+## Overview
+
+Provides visual feedback while a simulation run is in progress: a progress bar showing percentage completion, and a disabled Run button labelled "Running…". The simulation executes in small batches, yielding to the browser between each batch so the page remains responsive and the progress display can update. When the run finishes — or fails — the UI returns to its ready state.
+
+## User Story
+
+As a capacity planner, I want clear feedback while the simulation runs so that I know the tool is working, can see how far through it is, and am not tempted to click Run again or assume the page has frozen.
+
+## Functionality
+
+### Core Features
+
+- While a simulation run is in progress, the Run button must be disabled and its label must change to "Running…"
+- A progress bar must be visible during the run, advancing from 0% to 100% as runs complete
+- The progress percentage must be displayed numerically alongside the bar
+- The progress bar must advance incrementally throughout the run, not jump from 0% to 100% at the end
+- The page must remain responsive during the run — the user must be able to scroll, interact with other browser tabs, and observe the progress display updating
+- When the run completes, the progress bar must be hidden and the Run button must return to its active, correctly labelled state
+- If the run fails, the same restoration must occur and an error message must be shown
+
+### Automatic Run on Page Load
+
+The simulation runs automatically a short time after the page loads, using the default parameter values and the pre-populated example tasks. The same progress display applies to this initial run; a result is visible to the user without any interaction.
+
+### Incremental Progress
+
+Progress advances in proportion to how many simulation runs have completed. The display updates after each internal batch of runs, so on a short run a few visible steps occur; on a longer run the bar advances more smoothly. The display must never show progress jumping backwards.
+
+### User Interface
+
+The progress container — comprising the progress bar and its percentage label — must be hidden when no run is in progress and visible only during an active run. The Run button and the progress container are both in the settings area above the results panel.
+
+```
+┌────────────────────────────────────────────────┐
+│  [Run button — disabled, reads "Running…"]     │
+│  ┌──────────────────────────────────────┐  42% │
+│  │████████████████░░░░░░░░░░░░░░░░░░░░│      │
+│  └──────────────────────────────────────┘      │
+└────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+1. The user clicks Run (or the page load timer fires)
+2. The Run button is disabled and re-labelled; the progress container becomes visible
+3. Simulation runs are executed in batches; after each batch the progress percentage is recomputed as `(batches completed / total batches) × 100` and the display is updated
+4. Between batches, control is briefly returned to the browser, allowing the progress display to render and the page to remain interactive
+5. After the final batch, results are displayed
+6. The progress container is hidden and the Run button is restored — regardless of whether the run succeeded or failed
+
+## Security Considerations
+
+### Attack Surface
+
+#### Inbound Data Vectors
+
+- No user-supplied data reaches this feature. Progress values are computed internally from the count of completed and total batches.
+
+#### Outbound Data Vectors
+
+- **DOM rendering**: The progress bar width and percentage label are set from internally computed numeric values. No user-supplied strings are written to the DOM by this feature.
+
+#### Trust Boundaries
+
+- **Simulation to progress display**: Progress values are integers derived from batch counts. There is no path from external input to the progress display.
+
+### Threat Model
+
+- **Injection via progress values**: Progress is a computed percentage between 0 and 100; it is not derived from user input and cannot carry executable content. Risk: negligible.
+
+### Security Controls
+
+- Progress percentage values must be computed from internal counters only; no user-supplied data must influence the progress display.
+
+## Configuration
+
+This feature introduces no named configuration constants. The internal batch size governs how frequently the progress display updates but is not user-configurable and does not affect simulation results.
+
+## Usage Examples
+
+### A short run (1,000 simulations)
+
+```text
+User clicks Run.
+Button reads "Running…" and is disabled.
+Progress bar appears. Advances in ~10 visible steps.
+Bar reaches 100% and disappears.
+Results panel appears. Button reads "Run Timeline & Capacity Simulation" and is active.
+```
+
+### A long run near the complexity budget
+
+```text
+User clicks "Run anyway" after seeing the advisory warning.
+Button reads "Running…" and is disabled.
+Progress bar appears and advances gradually — the user can scroll and switch tabs.
+Bar reaches 100% and disappears.
+Results panel appears. Button is restored.
+```
+
+### An error during the run
+
+```text
+User clicks Run.
+An unexpected error occurs mid-run.
+An alert describes the error.
+The progress bar is hidden. The button is restored to its active state.
+The user can correct the configuration and run again.
+```
+
+## Validation & Error Handling
+
+- The Run button must be restored to its active state whether the run completes normally or throws an error; it must never remain permanently disabled
+- If an error occurs, an alert must inform the user and the progress container must be hidden so the UI does not appear stuck
+- The progress percentage must be clamped to the range 0–100; it must not display a value outside this range
+
+## Testing
+
+### Test Cases
+
+- Run button reads "Running…" and is disabled immediately after clicking Run
+- Progress bar is visible during the run and hidden before and after
+- Progress bar advances at least once before reaching 100% on a run of 200 or more simulations
+- Progress never decreases during a run
+- Run button is restored to its active state after a successful run
+- Run button is restored to its active state after a run that throws an error
+- On page load, the progress display appears and the results populate without the user clicking Run
+
+### Manual Testing Steps
+
+1. Load the application — confirm the progress bar is hidden on load, then briefly appears as the automatic run executes, then hides once results appear
+2. Click Run — confirm the button immediately reads "Running…" and cannot be clicked again
+3. Set simulations to 5,000 and click Run — confirm the progress bar visibly advances in multiple steps before completing
+4. Confirm the page remains scrollable and the progress percentage updates visually during the run
+5. Confirm that after the run the button reads "Run Timeline & Capacity Simulation" and is active
+
+## Performance Considerations
+
+- Yielding to the browser between batches introduces a small overhead per batch; this is intentional and keeps the page responsive
+- The frequency of progress updates is proportional to run count: a 1,000-run simulation yields roughly ten times; a 10,000-run simulation yields roughly one hundred times. The overhead per yield is a few milliseconds and does not materially affect total runtime
+- The progress bar itself is a simple DOM width update; it introduces no meaningful rendering cost
+
+## Known Limitations
+
+- The progress bar advances in steps, not continuously. On short runs the steps are large and the bar appears to jump; on longer runs the steps are smaller and the advance appears smoother
+- The simulation runs on the browser's main thread. Although the page remains interactive between batches, the browser cannot render other animations or handle events during each batch
+- There is no cancel button; a run in progress must complete before the user can change parameters and run again
+
+## Future Enhancements
+
+- Move the simulation loop to a Web Worker so the main thread is never blocked, even within a batch
+- Add a cancel button that aborts the current run and restores the UI immediately
+- Show an estimated time remaining alongside the progress percentage, based on the elapsed time per batch
+
+## Related Documentation
+
+- [Simulation Parameters](../01-configure/simulation-parameters.md) — the `simulations` and `programQuantity` parameters that determine how long a run takes
+- [Simulation Complexity Limits](./simulation-complexity-limits.md) — the advisory warning that precedes long runs; the progress display is the feedback mechanism during those runs
+- [Report Structure](../03-report/report-structure.md) — the results panel that appears when the run completes


### PR DESCRIPTION
## Summary

- Adds three feature documents covering the previously undocumented `02-simulate` section, identified during a gap analysis against the implementation
- **Simulation Progress** — progress bar, Run button state transitions, and async batch execution that keeps the browser responsive during long runs
- **Effort Sampling** — PERT/Beta distribution sampling for work effort and wait time, skip logic, and edge-case handling (zero range, inverted range, extreme PERT ratios)
- **Capacity-Constrained Scheduling** — task chunking for large work items, greedy weekly capacity placement, wait time handling, and the fallback for oversubscribed configurations

## Test plan

- [ ] Each document follows the template structure with all mandatory sections present
- [ ] Behaviours described match the implementation in `src/simulation.js` and `src/ui.js`
- [ ] Cross-links between documents and to existing docs resolve correctly
- [ ] No function names or line numbers appear in the user-facing feature docs (effort-sampling, simulation-progress, capacity-constrained-scheduling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)