### PR TITLE
docs: add ADR for threat modeling approach (threatcl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,17 @@ npm test
 ```
 Runs property-based tests in `test/` using vitest and fast-check.
 
+### Threat Model
+```
+npm run threatmodel
+```
+Validates the HCL source, then generates dashboard markdown and an SVG data flow diagram into `docs/threatmodel/` (gitignored).
+
+```
+npm run threatmodel:validate
+```
+Validates `threatmodel/*.hcl` only — suitable as a lightweight CI check. Requires `threatcl` to be installed (`brew install threatcl` or equivalent).
+
 ### Development Tools
 - JavaScript lint: `npx eslint src/simulation.js src/ui.js`
 - HTML validation: `npx html-validate web/index.html`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ MIT License - see LICENSE file for details
 
 - **[Contributing Guide](docs/development/CONTRIBUTING.md)**: How to contribute to this project
 - **[Security Policy](docs/development/SECURITY.md)**: Security considerations and vulnerability reporting
+- **[Threat Model](docs/adr/security/threat-modeling.md)**: Threat modeling approach and the threatcl model in `threatmodel/`
 - **[Architecture Decisions](docs/adr/)**: Technical decisions and their rationale
 - **[Feature Documentation](docs/features/)**: Detailed feature specifications
 

--- a/docs/adr/security/threat-modeling.md
+++ b/docs/adr/security/threat-modeling.md
@@ -1,0 +1,53 @@
+# ADR: Threat Modeling Approach
+
+Threat models for this project are authored as threatcl HCL files in `threatmodel/` and built via `npm run threatmodel`.
+
+## Decision
+
+1. **Threat models are stored as threatcl HCL source files in `threatmodel/`.** The HCL format is the source of truth; generated output (dashboard markdown, DFD diagrams) is a build artefact and is gitignored.
+2. **`npm run threatmodel` generates the full output;** `npm run threatmodel:validate` validates the HCL and is suitable for CI.
+3. **The threat model is updated alongside material changes to the application's attack surface** — new input paths, new dependencies, or significant changes to data handling.
+
+## Rationale
+
+**Reviewability.** HCL is compact and diff-friendly. Changes to threats, controls, or STRIDE classifications are visible as meaningful line-level diffs in pull requests. JSON-based tools (Threat Dragon) produce large opaque files that are difficult to review. A markdown-only model is reviewable but cannot be validated or generate diagrams.
+
+**Validation.** `threatcl validate` catches structural errors — broken `information_asset_refs`, unknown STRIDE values, malformed blocks — before they reach main. This is the same principle as ESLint and html-validate in the existing `validate` script.
+
+**Generated DFD.** The data flow diagram is derived from the same source as the threat descriptions, so the two cannot diverge. Maintaining a diagram separately from the threat model (as most manual approaches require) creates a common source of drift.
+
+**Proportionate overhead.** threatcl is a single binary with no runtime dependencies. For a project of this size the tooling cost is low relative to the structure it provides.
+
+## Consequences
+
+### Benefits
+
+- Threat model changes are code-reviewed on the same PRs as the features they describe
+- `threatcl validate` can be added to CI as a lightweight gate
+- DFD and dashboard output are generated consistently rather than maintained by hand
+- HCL source is readable without running any tooling
+
+### Risks
+
+- threatcl is an external binary that must be installed separately; it is not declared in `package.json` and cannot be installed via `npm install`. Contributors need to install it independently.
+- The HCL schema has a learning curve. Unlike a blank markdown file, authoring requires familiarity with threatcl's block types and valid field values.
+- threatcl is a smaller ecosystem tool; long-term maintenance is less certain than OWASP-backed alternatives.
+
+## Rejected Approaches
+
+**OWASP Threat Dragon.** A well-supported visual tool with a JSON model file. Rejected primarily because the JSON output is verbose and not practically reviewable in PRs — the diff for a minor change is hundreds of lines of coordinates and metadata. It also has no build/validate step that integrates naturally with an npm workflow.
+
+**pytm.** A Python-based code-first threat modeling library that generates DFDs and reports. Technically well-suited to the code-first approach we wanted, but adds a Python toolchain dependency to a JavaScript project. The project is less actively maintained than threatcl.
+
+**Threagile.** YAML-based threat modeling with report generation. Requires Docker or a Java runtime, which is disproportionate overhead for a project this size. YAML models also grow verbose quickly and lack strong validation of STRIDE or CIA fields.
+
+**Microsoft Threat Modeling Tool.** STRIDE-native and widely referenced in literature. Rejected because it is Windows-only with an XML format that has a poor version control story and no CI integration path.
+
+**Unstructured markdown.** A hand-written markdown document would fit the existing docs style and have no tooling dependency. Rejected because it cannot be validated, cannot generate a DFD from the same source as the threat descriptions, and has no structural enforcement — omitting impacts, STRIDE, or controls is silently permitted.
+
+## References
+
+- [threatcl documentation](https://github.com/threatcl/threatcl)
+- [threatmodel/montycap.hcl](../../threatmodel/montycap.hcl)
+- [dom-xss-prevention.md](dom-xss-prevention.md)
+- [security-policy.md](security-policy.md)

--- a/docs/adr/structure/repository-layout.md
+++ b/docs/adr/structure/repository-layout.md
@@ -11,6 +11,7 @@ montycap/
 ├── test/                  Automated tests
 ├── web/                   Built artifact (gitignored)
 ├── docs/                  All project documentation
+├── threatmodel/           threatcl HCL threat model source files
 ├── .github/               GitHub workflows and configuration
 └── [root config files]    Project metadata and tooling configuration
 ```
@@ -18,6 +19,10 @@ montycap/
 ### `web/` — Built artifact
 
 `web/index.html` is the assembled application — a self-contained HTML file requiring no server or runtime dependencies. It is gitignored; every build produces it fresh from `src/`.
+
+### `threatmodel/` — Threat model source
+
+threatcl HCL files defining the application's threat model. Generated output (dashboard markdown, DFD diagrams) is written to `docs/threatmodel/` and gitignored. See [threat-modeling.md](../security/threat-modeling.md).
 
 ### `docs/` — Documentation
 
@@ -30,7 +35,7 @@ montycap/
 
 **`src/` contains the source files assembled into the deployed artifact.** The internal structure of those files — how they are divided and why — is covered in [source-and-build.md](source-and-build.md).
 
-**`web/index.html` is not versioned.** It is deterministically produced from `src/` on every build. Committing it alongside its sources creates drift risk and unnecessary diff noise; the gitignore enforces that only source is versioned.
+**`web/index.html` and `docs/threatmodel/` are not versioned.** Both are deterministically produced by their respective build steps (`npm run build` and `npm run threatmodel`). Committing generated output alongside its sources creates drift risk and unnecessary diff noise; the gitignore enforces that only source is versioned.
 
 **`docs/` collects all documentation under one tree.** Keeping documentation in a single directory makes it easy to locate, cross-link, and apply consistent standards. Subdirectories group by audience and purpose rather than by code layer.
 
@@ -57,9 +62,11 @@ montycap/
 
 - [source-and-build.md](source-and-build.md)
 - [documentation.md](documentation.md)
+- [threat-modeling.md](../security/threat-modeling.md)
 
 ## History
 
 - **Single file at root** (`web/index.html` alongside flat documentation) — the original structure; simple but did not separate code from docs and made linting and testing impractical.
 - **`web/` and `docs/` directories introduced** — code and documentation separated as the project grew and a more navigable layout was needed.
 - **`src/`, `scripts/`, and `test/` added** — source split into separate files to enable direct linting and importable modules; the build step was introduced to reassemble them into `web/index.html`, with tests arriving alongside it.
+- **`threatmodel/` added** — threatcl HCL threat model introduced as a separate source directory following the same pattern as `src/`; generated output gitignored.

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to this project! This document provi
 - Text editor or IDE
 - Node.js (for development tools)
 - Python 3.6+ (for pre-commit hooks)
+- [threatcl](https://github.com/threatcl/threatcl) (for threat model generation — `brew install threatcl` on macOS)
 
 ### Development Setup
 
@@ -182,6 +183,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 - Changing existing functionality
 - Fixing security issues
 - Modifying file formats or data structures
+- Adding new input paths, external dependencies, or data handling — update `threatmodel/montycap.hcl` to reflect any changes to the attack surface
 
 ### Documentation Types
 
@@ -206,7 +208,7 @@ All contributions undergo security review focusing on:
 - Output encoding
 - Client-side data handling
 - External dependency security
-- Attack surface analysis
+- Attack surface analysis — if the change introduces a new input path or dependency, update `threatmodel/montycap.hcl` and run `npm run threatmodel:validate`
 - Pre-commit hook security checks
 
 ## Getting Help


### PR DESCRIPTION
## Summary

- Adds `docs/adr/security/threat-modeling.md` documenting the decision to use threatcl for threat modeling, with rationale and five rejected alternatives (Threat Dragon, pytm, Threagile, Microsoft TMT, unstructured markdown)
- Updates `docs/adr/structure/repository-layout.md` to document the `threatmodel/` source directory and gitignored generated output
- Updates `CONTRIBUTING.md` with threatcl as a prerequisite and guidance on when to update the threat model
- Updates `README.md` to link the threat model ADR from the Documentation section
- Updates `CLAUDE.md` to document the `npm run threatmodel` and `npm run threatmodel:validate` scripts

Note: this ADR documents the decision only. The threatcl proof-of-concept (the HCL source, npm scripts, and `.gitignore` change) is on a separate branch (`chore/threatmodel`) and is not included here.

## Test plan

- [ ] ADR is readable and accurately describes the decision and rejected alternatives
- [ ] Links in the ADR resolve correctly within the repository
- [ ] `npm run validate` passes