### PR TITLE
docs: expand Threagile entry in threat modeling ADR with PoC findings

### DIFF
--- a/docs/adr/security/threat-modeling.md
+++ b/docs/adr/security/threat-modeling.md
@@ -45,7 +45,29 @@ Threat models for this project are authored as threatcl HCL files in `threatmode
 
 *Toolchain overhead.* pytm is a Python library, not a CLI binary. It requires a virtual environment (`python3 -m venv`), a `requirements.txt`, and graphviz for DFD output — three separate installation steps versus one binary for threatcl. This is a meaningful barrier in a JavaScript project where no Python toolchain is otherwise required.
 
-**Threagile.** YAML-based threat modeling with report generation. Requires Docker or a Java runtime, which is disproportionate overhead for a project this size. YAML models also grow verbose quickly and lack strong validation of STRIDE or CIA fields.
+**Threagile** (evaluated via PoC on `chore/threagile-poc`; model at `threatmodel/threagile/montycap.yaml`). YAML-based threat modeling with PDF report generation, quantified risk scoring, and deep integration with OWASP ASVS. The initial rejection (Docker overhead, YAML verbosity, weak validation) was written without empirical evidence and is replaced here with PoC findings.
+
+The PoC model covers the runtime browser app, CDN dependencies, GitHub repository, GitHub Actions CI/CD pipeline, GitHub Pages hosting, and all five third-party GitHub Actions — 14 technical assets, 7 data assets, 4 trust boundaries, and 73 risk tracking entries. The existing threatcl model covers only the runtime app and CDN; a fair like-for-like comparison would require extending it to the same CI/CD scope (see below).
+
+*Advantages found:*
+
+- **ASVS alignment.** Every risk category maps to an ASVS control reference and CWE, providing a recognised security standard anchor that threatcl lacks.
+- **Full SDLC modeling.** Threagile's trust boundary and communication link model covers the CI/CD pipeline, GitHub infrastructure, and third-party action supply chain as first-class elements. Whether threatcl can cover the same scope with comparable fidelity is an open question (see below).
+- **Richer risk tracking.** Each tracking entry carries status, justification, ticket reference, date, and reviewer. threatcl represents mitigation only as a `risk_reduction` percentage per control, with no per-risk status or audit trail.
+- **Quantified risk ratings.** Severity, likelihood, and data breach probability are derived from model attributes (confidentiality, integrity, asset classification) rather than manually assigned.
+- **PDF report and two diagram types.** A data flow diagram and a data asset diagram are generated from the same YAML source. The PDF is structured for stakeholder review.
+- **Security requirements and abuse cases as first-class fields.** Structural YAML elements with schema validation, not free-text prose.
+
+*Limitations found:*
+
+- **High false positive rate.** 50 of 73 risks (68%) were false positives. Threagile's built-in rule set assumes server-side architecture: it flags SSRF on every outbound HTTPS call (CDN loads, npm fetches, GitHub Actions invocations), missing authentication for public resources, missing WAF for external entities, and CSRF on a static app. Each false positive requires a tracked justification entry. The upfront investment is significant; ongoing maintenance is lower once the baseline is established.
+- **Risk tracking ID fragility.** Synthetic IDs encode the full asset/link/trust-boundary/data-asset hierarchy. Any model restructuring — renaming an asset, retargeting a communication link — orphans existing entries. Orphaned IDs must be discovered from `risks.json` and corrected manually; they are not surfaced without the `-ignore-orphaned-risk-tracking` flag.
+- **Docker dependency.** There is no npm-installable Threagile binary; Docker is required. This adds a contributor prerequisite not otherwise present in the toolchain.
+- **Data asset diagram limitation.** Arrows always point toward assets (consumed-by / stored-in). There is no produced-by relationship, so outputs such as simulation results and exported CSV appear as inputs in the diagram.
+
+*Open question — threatcl at equivalent scope:*
+
+A direct comparison between the two tools is not yet possible because the threatcl model covers only the runtime application and CDN dependencies. A PoC extending the HCL model to include GitHub repository, GitHub Actions CI/CD, GitHub Pages, and the five third-party actions would establish whether the SDLC modeling gap is a real limitation of threatcl or simply an authoring gap in the current model.
 
 **Microsoft Threat Modeling Tool.** STRIDE-native and widely referenced in literature. Rejected because it is Windows-only with an XML format that has a poor version control story and no CI integration path.
 
@@ -54,6 +76,8 @@ Threat models for this project are authored as threatcl HCL files in `threatmode
 ## References
 
 - [threatcl documentation](https://github.com/threatcl/threatcl)
+- [Threagile documentation](https://threagile.io)
 - [threatmodel/montycap.hcl](../../threatmodel/montycap.hcl)
+- [threatmodel/threagile/montycap.yaml](../../threatmodel/threagile/montycap.yaml) — Threagile PoC model
 - [dom-xss-prevention.md](dom-xss-prevention.md)
 - [security-policy.md](security-policy.md)


### PR DESCRIPTION
## Summary

- Replaces the two-sentence unsupported Threagile rejection in the threat modeling ADR with empirical findings from the `chore/threagile-poc` PoC
- Documents advantages: ASVS alignment, full SDLC modeling (CI/CD pipeline, GitHub infrastructure, third-party actions), richer per-risk status tracking, quantified risk ratings, PDF report, security requirements as first-class fields
- Documents limitations: 68% false positive rate from server-side rule assumptions, fragile synthetic risk IDs, Docker dependency, data asset diagram direction limitation
- Notes that a fair tool comparison requires a threatcl PoC at equivalent scope (covering GitHub, GitHub Actions, GitHub Pages, and third-party actions) — which has not yet been done

## Test plan

- [ ] Read the updated Threagile section in `docs/adr/security/threat-modeling.md` and confirm findings match what was observed in `chore/threagile-poc`
- [ ] Confirm the "Open question — threatcl at equivalent scope" paragraph accurately frames the next step

🤖 Generated with [Claude Code](https://claude.com/claude-code)