### PR TITLE
Fix stale version comment on upload-sarif action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -76,6 +76,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,7 +41,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- The pinned commit `99df26d4f13e...` for `github/codeql-action/upload-sarif` actually corresponds to tag `v4.37.0`, but the trailing comment in both workflows still said `v3.29.5` — likely left over from before the hash was last bumped.
- Corrected the comment in `scorecards.yml` and `security-scan.yml` to `v4.37.0` so it accurately reflects the version actually pinned by the hash.

## Test plan
- [x] Verified via `gh api repos/github/codeql-action/tags` that the pinned SHA matches tag `v4.37.0`, not `v3.29.5`
- [x] No functional change — action hash unchanged, only the comment corrected